### PR TITLE
Fix handling of invalid files

### DIFF
--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:math';
 import 'dart:typed_data';
+import 'package:path/path.dart';
 
 import 'package:connectivity/connectivity.dart';
 import 'package:dio/dio.dart';
@@ -402,7 +403,8 @@ class FileUploader {
   }
 
   Future _onInvalidFileError(File file) async {
-    _logger.warning("Invalid file encountered: " + file.toString());
+    String ext = file.title == null ? "no title" : extension(file.title);
+    _logger.severe("Invalid file: (ext: $ext) encountered: " + file.toString());
     await FilesDB.instance.deleteLocalFile(file);
     await LocalSyncService.instance.trackInvalidFile(file);
     throw InvalidFileError();

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -278,7 +278,7 @@ class FileUploader {
         mediaUploadData = await getUploadDataFromEnteFile(file);
       } catch (e) {
         if (e is InvalidFileError) {
-          _onInvalidFileError(file);
+          await _onInvalidFileError(file);
         } else {
           rethrow;
         }


### PR DESCRIPTION
When we don't await on _onInvalidFileError, then it result i the following  NPE  error:

> NoSuchMethodError: The getter 'sourceFile' was called on null.