### PR TITLE
Remove add/remove file and share collection action for incoming collection 

### DIFF
--- a/lib/ui/collection_page.dart
+++ b/lib/ui/collection_page.dart
@@ -19,7 +19,7 @@ class CollectionPage extends StatelessWidget {
 
   CollectionPage(this.c,
       {this.tagPrefix = "collection",
-      this.appBarType = GalleryAppBarType.collection,
+      this.appBarType = GalleryAppBarType.owned_collection,
       Key key})
       : super(key: key);
 

--- a/lib/ui/collection_page.dart
+++ b/lib/ui/collection_page.dart
@@ -14,9 +14,13 @@ import 'gallery_app_bar_widget.dart';
 class CollectionPage extends StatelessWidget {
   final CollectionWithThumbnail c;
   final String tagPrefix;
+  final GalleryAppBarType appBarType;
   final _selectedFiles = SelectedFiles();
 
-  CollectionPage(this.c, {this.tagPrefix = "collection", Key key})
+  CollectionPage(this.c,
+      {this.tagPrefix = "collection",
+      this.appBarType = GalleryAppBarType.collection,
+      Key key})
       : super(key: key);
 
   @override
@@ -44,7 +48,7 @@ class CollectionPage extends StatelessWidget {
         Container(
           height: Platform.isAndroid ? 80 : 100,
           child: GalleryAppBarWidget(
-            GalleryAppBarType.collection,
+            appBarType,
             c.collection.name,
             _selectedFiles,
             collection: c.collection,

--- a/lib/ui/gallery_app_bar_widget.dart
+++ b/lib/ui/gallery_app_bar_widget.dart
@@ -20,10 +20,10 @@ import 'package:photos/utils/toast_util.dart';
 enum GalleryAppBarType {
   homepage,
   local_folder,
+  // indicator for gallery view of collections shared with the user
   shared_collection,
-  collection,
-  search_results,
-  incoming_collection,
+  owned_collection,
+  search_results
 }
 
 class GalleryAppBarWidget extends StatefulWidget {
@@ -106,7 +106,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     List<Widget> actions = <Widget>[];
     if (Configuration.instance.hasConfiguredAccount() &&
         (widget.type == GalleryAppBarType.local_folder ||
-            widget.type == GalleryAppBarType.collection)) {
+            widget.type == GalleryAppBarType.owned_collection)) {
       actions.add(IconButton(
         icon: Icon(Icons.person_add),
         onPressed: () {
@@ -168,7 +168,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     List<Widget> actions = <Widget>[];
     // skip add button for incoming collection till this feature is implemented
     if (Configuration.instance.hasConfiguredAccount() &&
-        widget.type != GalleryAppBarType.incoming_collection) {
+        widget.type != GalleryAppBarType.shared_collection) {
       actions.add(IconButton(
         icon:
             Icon(Platform.isAndroid ? Icons.add_outlined : CupertinoIcons.add),
@@ -193,9 +193,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
           _showDeleteSheet(context);
         },
       ));
-    } else if (widget.type == GalleryAppBarType.collection ||
-        (widget.type == GalleryAppBarType.shared_collection &&
-            widget.collection.owner.id == Configuration.instance.getUserID())) {
+    } else if (widget.type == GalleryAppBarType.owned_collection) {
       if (widget.collection.type == CollectionType.folder) {
         actions.add(IconButton(
           icon: Icon(Platform.isAndroid

--- a/lib/ui/gallery_app_bar_widget.dart
+++ b/lib/ui/gallery_app_bar_widget.dart
@@ -23,6 +23,7 @@ enum GalleryAppBarType {
   shared_collection,
   collection,
   search_results,
+  incoming_collection,
 }
 
 class GalleryAppBarWidget extends StatefulWidget {
@@ -165,7 +166,9 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
 
   List<Widget> _getActions(BuildContext context) {
     List<Widget> actions = <Widget>[];
-    if (Configuration.instance.hasConfiguredAccount()) {
+    // skip add button for incoming collection till this feature is implemented
+    if (Configuration.instance.hasConfiguredAccount() &&
+        widget.type != GalleryAppBarType.incoming_collection) {
       actions.add(IconButton(
         icon:
             Icon(Platform.isAndroid ? Icons.add_outlined : CupertinoIcons.add),

--- a/lib/ui/share_collection_widget.dart
+++ b/lib/ui/share_collection_widget.dart
@@ -32,6 +32,7 @@ class _SharingDialogState extends State<SharingDialog> {
   bool _showEntryField = false;
   List<User> _sharees;
   String _email;
+  final Logger _logger = Logger("SharingDialogState");
 
   @override
   Widget build(BuildContext context) {
@@ -208,14 +209,14 @@ class _SharingDialogState extends State<SharingDialog> {
       final dialog = createProgressDialog(context, "sharing...");
       await dialog.show();
       final collection = widget.collection;
-      if (collection.type == CollectionType.folder) {
-        final path =
-            CollectionsService.instance.decryptCollectionPath(collection);
-        if (!Configuration.instance.getPathsToBackUp().contains(path)) {
-          await Configuration.instance.addPathToFoldersToBeBackedUp(path);
-        }
-      }
       try {
+        if (collection.type == CollectionType.folder) {
+          final path =
+              CollectionsService.instance.decryptCollectionPath(collection);
+          if (!Configuration.instance.getPathsToBackUp().contains(path)) {
+            await Configuration.instance.addPathToFoldersToBeBackedUp(path);
+          }
+        }
         await CollectionsService.instance
             .share(widget.collection.id, email, publicKey);
         await dialog.hide();
@@ -260,6 +261,7 @@ class _SharingDialogState extends State<SharingDialog> {
             },
           );
         } else {
+          _logger.severe("failed to share collection", e);
           showGenericErrorDialog(context);
         }
       }

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -14,6 +14,7 @@ import 'package:photos/models/collection_items.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/ui/collection_page.dart';
 import 'package:photos/ui/collections_gallery_widget.dart';
+import 'package:photos/ui/gallery_app_bar_widget.dart';
 import 'package:photos/ui/loading_widget.dart';
 import 'package:photos/ui/thumbnail_widget.dart';
 import 'package:photos/utils/navigation_util.dart';
@@ -418,7 +419,11 @@ class IncomingCollectionItem extends StatelessWidget {
         ],
       ),
       onTap: () {
-        routeToPage(context, CollectionPage(c, tagPrefix: "shared_collection"));
+        routeToPage(
+            context,
+            CollectionPage(c,
+                appBarType: GalleryAppBarType.incoming_collection,
+                tagPrefix: "shared_collection"));
       },
     );
   }

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -347,6 +347,7 @@ class OutgoingCollectionItem extends StatelessWidget {
       onTap: () {
         final page = CollectionPage(
           c,
+          appBarType: GalleryAppBarType.owned_collection,
           tagPrefix: "outgoing_collection",
         );
         routeToPage(context, page);
@@ -422,7 +423,7 @@ class IncomingCollectionItem extends StatelessWidget {
         routeToPage(
             context,
             CollectionPage(c,
-                appBarType: GalleryAppBarType.incoming_collection,
+                appBarType: GalleryAppBarType.shared_collection,
                 tagPrefix: "shared_collection"));
       },
     );


### PR DESCRIPTION
* Hide add selected files to another collection button.
* Add folks to album & remove/delete from album is also not visible now
* ShareDialog: catch & log unhandled err  during collection path decryption err