### PR TITLE
Hide incoming collections in main gallery

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -332,14 +332,14 @@ class FilesDB {
   }
 
   Future<FileLoadResult> getAllUploadedFiles(int startTime, int endTime,
-      {int limit, bool asc}) async {
+      int ownerID, {int limit, bool asc}) async {
     final db = await instance.database;
     final order = (asc ?? false ? 'ASC' : 'DESC');
     final results = await db.query(
       table,
       where:
-          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1)',
-      whereArgs: [startTime, endTime],
+          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnOwnerID IS NULL OR $columnOwnerID = ?) AND ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1)',
+      whereArgs: [startTime, endTime, ownerID],
       orderBy:
           '$columnCreationTime ' + order + ', $columnModificationTime ' + order,
       limit: limit,
@@ -348,15 +348,15 @@ class FilesDB {
     return FileLoadResult(files, files.length == limit);
   }
 
-  Future<FileLoadResult> getAllLocalAndUploadedFiles(int startTime, int endTime,
+  Future<FileLoadResult> getAllLocalAndUploadedFiles(int startTime, int endTime, int ownerID,
       {int limit, bool asc}) async {
     final db = await instance.database;
     final order = (asc ?? false ? 'ASC' : 'DESC');
     final results = await db.query(
       table,
       where:
-          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnLocalID IS NOT NULL OR ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1))',
-      whereArgs: [startTime, endTime],
+          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnOwnerID IS NULL OR $columnOwnerID = ?) AND ($columnLocalID IS NOT NULL OR ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1))',
+      whereArgs: [startTime, endTime, ownerID],
       orderBy:
           '$columnCreationTime ' + order + ', $columnModificationTime ' + order,
       limit: limit,
@@ -366,7 +366,7 @@ class FilesDB {
   }
 
   Future<FileLoadResult> getImportantFiles(
-      int startTime, int endTime, List<String> paths,
+      int startTime, int endTime, int ownerID, List<String> paths,
       {int limit, bool asc}) async {
     final db = await instance.database;
     String inParam = "";
@@ -378,8 +378,8 @@ class FilesDB {
     final results = await db.query(
       table,
       where:
-          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND (($columnLocalID IS NOT NULL AND $columnDeviceFolder IN ($inParam)) OR ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1))',
-      whereArgs: [startTime, endTime],
+          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnOwnerID IS NULL OR $columnOwnerID = ?) AND (($columnLocalID IS NOT NULL AND $columnDeviceFolder IN ($inParam)) OR ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1))',
+      whereArgs: [startTime, endTime, ownerID],
       orderBy:
           '$columnCreationTime ' + order + ', $columnModificationTime ' + order,
       limit: limit,

--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -338,7 +338,7 @@ class FilesDB {
     final results = await db.query(
       table,
       where:
-          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND ($columnOwnerID IS NULL OR $columnOwnerID = ?) AND ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1)',
+          '$columnCreationTime >= ? AND $columnCreationTime <= ? AND  $columnOwnerID = ? AND ($columnCollectionID IS NOT NULL AND $columnCollectionID IS NOT -1)',
       whereArgs: [startTime, endTime, ownerID],
       orderBy:
           '$columnCreationTime ' + order + ', $columnModificationTime ' + order,

--- a/lib/ui/detail_page.dart
+++ b/lib/ui/detail_page.dart
@@ -99,6 +99,7 @@ class _DetailPageState extends State<DetailPage> {
       appBar: FadingAppBar(
         _files[_selectedIndex],
         _onFileDeleted,
+        Configuration.instance.getUserID(),
         100,
         key: _appBarKey,
       ),

--- a/lib/ui/fading_app_bar.dart
+++ b/lib/ui/fading_app_bar.dart
@@ -24,10 +24,12 @@ class FadingAppBar extends StatefulWidget implements PreferredSizeWidget {
   final File file;
   final Function(File) onFileDeleted;
   final double height;
+  final int userId;
 
   FadingAppBar(
     this.file,
     this.onFileDeleted,
+    this.userId,
     this.height, {
     Key key,
   }) : super(key: key);
@@ -83,7 +85,9 @@ class FadingAppBarState extends State<FadingAppBar> {
 
   AppBar _buildAppBar() {
     final List<Widget> actions = [];
-    actions.add(_getFavoriteButton());
+    if (widget.file.ownerID == null || widget.file.ownerID == widget.userId) {
+      actions.add(_getFavoriteButton());
+    }
     actions.add(PopupMenuButton(
       itemBuilder: (context) {
         final List<PopupMenuItem> items = [];

--- a/lib/ui/fading_app_bar.dart
+++ b/lib/ui/fading_app_bar.dart
@@ -85,6 +85,7 @@ class FadingAppBarState extends State<FadingAppBar> {
 
   AppBar _buildAppBar() {
     final List<Widget> actions = [];
+    // only show fav option for files owned by the user
     if (widget.file.ownerID == null || widget.file.ownerID == widget.userId) {
       actions.add(_getFavoriteButton());
     }
@@ -109,22 +110,26 @@ class FadingAppBarState extends State<FadingAppBar> {
             ),
           );
         }
-        items.add(
-          PopupMenuItem(
-            value: 2,
-            child: Row(
-              children: [
-                Icon(Platform.isAndroid
-                    ? Icons.delete_outline
-                    : CupertinoIcons.delete),
-                Padding(
-                  padding: EdgeInsets.all(8),
-                ),
-                Text("delete"),
-              ],
+        // only show delete option for files owned by the user
+        if (widget.file.ownerID == null ||
+            widget.file.ownerID == widget.userId) {
+          items.add(
+            PopupMenuItem(
+              value: 2,
+              child: Row(
+                children: [
+                  Icon(Platform.isAndroid
+                      ? Icons.delete_outline
+                      : CupertinoIcons.delete),
+                  Padding(
+                    padding: EdgeInsets.all(8),
+                  ),
+                  Text("delete"),
+                ],
+              ),
             ),
-          ),
-        );
+          );
+        }
         return items;
       },
       onSelected: (value) {

--- a/lib/ui/fading_app_bar.dart
+++ b/lib/ui/fading_app_bar.dart
@@ -24,12 +24,12 @@ class FadingAppBar extends StatefulWidget implements PreferredSizeWidget {
   final File file;
   final Function(File) onFileDeleted;
   final double height;
-  final int userId;
+  final int userID;
 
   FadingAppBar(
     this.file,
     this.onFileDeleted,
-    this.userId,
+    this.userID,
     this.height, {
     Key key,
   }) : super(key: key);
@@ -86,7 +86,7 @@ class FadingAppBarState extends State<FadingAppBar> {
   AppBar _buildAppBar() {
     final List<Widget> actions = [];
     // only show fav option for files owned by the user
-    if (widget.file.ownerID == null || widget.file.ownerID == widget.userId) {
+    if (widget.file.ownerID == null || widget.file.ownerID == widget.userID) {
       actions.add(_getFavoriteButton());
     }
     actions.add(PopupMenuButton(
@@ -112,7 +112,7 @@ class FadingAppBarState extends State<FadingAppBar> {
         }
         // only show delete option for files owned by the user
         if (widget.file.ownerID == null ||
-            widget.file.ownerID == widget.userId) {
+            widget.file.ownerID == widget.userID) {
           items.add(
             PopupMenuItem(
               value: 2,

--- a/lib/ui/gallery.dart
+++ b/lib/ui/gallery.dart
@@ -100,18 +100,29 @@ class _GalleryState extends State<Gallery> {
 
   Future<FileLoadResult> _loadFiles({int limit}) async {
     _logger.info("Loading files");
-    final startTime = DateTime.now().microsecondsSinceEpoch;
-    final result = await widget.asyncLoader(
-        kGalleryLoadStartTime, DateTime.now().microsecondsSinceEpoch,
-        limit: limit);
-    final endTime = DateTime.now().microsecondsSinceEpoch;
-    final duration = Duration(microseconds: endTime - startTime);
-    _logger.info("Time taken to load " +
-        result.files.length.toString() +
-        " files :" +
-        duration.inMilliseconds.toString() +
-        "ms");
-    return result;
+    try {
+      final startTime = DateTime
+          .now()
+          .microsecondsSinceEpoch;
+      final result = await widget.asyncLoader(
+          kGalleryLoadStartTime, DateTime
+          .now()
+          .microsecondsSinceEpoch,
+          limit: limit);
+      final endTime = DateTime
+          .now()
+          .microsecondsSinceEpoch;
+      final duration = Duration(microseconds: endTime - startTime);
+      _logger.info("Time taken to load " +
+          result.files.length.toString() +
+          " files :" +
+          duration.inMilliseconds.toString() +
+          "ms");
+      return result;
+    } catch(e, s) {
+      _logger.severe("failed to load files", e, s);
+      rethrow;
+    }
   }
 
   // Collates files and returns `true` if it resulted in a gallery reload

--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:logging/logging.dart';
 import 'package:move_to_background/move_to_background.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -45,7 +46,6 @@ import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/navigation_util.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:uni_links/uni_links.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class HomeWidget extends StatefulWidget {
   const HomeWidget({Key key}) : super(key: key);
@@ -336,18 +336,19 @@ class _HomeWidgetState extends State<HomeWidget> {
     final gallery = Gallery(
       asyncLoader: (creationStartTime, creationEndTime, {limit, asc}) {
         final importantPaths = Configuration.instance.getPathsToBackUp();
+        final ownerID = Configuration.instance.getUserID();
         if (importantPaths.isNotEmpty) {
           return FilesDB.instance.getImportantFiles(
-              creationStartTime, creationEndTime, importantPaths.toList(),
+              creationStartTime, creationEndTime, ownerID, importantPaths.toList(),
               limit: limit, asc: asc);
         } else {
           if (LocalSyncService.instance.hasGrantedLimitedPermissions()) {
             return FilesDB.instance.getAllLocalAndUploadedFiles(
-                creationStartTime, creationEndTime,
+                creationStartTime, creationEndTime, ownerID,
                 limit: limit, asc: asc);
           } else {
             return FilesDB.instance.getAllUploadedFiles(
-                creationStartTime, creationEndTime,
+                creationStartTime, creationEndTime, ownerID,
                 limit: limit, asc: asc);
           }
         }


### PR DESCRIPTION
**Test Plan**
Verified that

- [x] incoming collections are not shown on main gallery
- [x]  photos which are queued for upload are shown in the main gallery (with owner_id as null)
- [x] favorite option is not visible on files not owned by the user
- [x] delete  option is not visible on files not owned by the user