### PR TITLE
[dart-null-safety] upgrade packages

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: animate_do
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.5"
+    version: "2.0.0"
   archive:
     dependency: "direct main"
     description:
@@ -91,14 +91,14 @@ packages:
       name: computer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   confetti:
     dependency: "direct main"
     description:
       name: confetti
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.5"
+    version: "0.6.0"
   connectivity:
     dependency: "direct main"
     description:
@@ -428,7 +428,7 @@ packages:
       name: flutter_windowmanager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2"
+    version: "0.2.0"
   fluttercontactpicker:
     dependency: "direct main"
     description:
@@ -592,6 +592,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -654,7 +661,7 @@ packages:
       name: page_transition
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7+6"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
@@ -770,7 +777,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "6.0.0"
   quiver:
     dependency: "direct main"
     description:
@@ -778,13 +785,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  random_color:
-    dependency: transitive
-    description:
-      name: random_color
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
   receive_sharing_intent:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,13 +17,13 @@ environment:
   sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
-  animate_do: ^1.7.2
+  animate_do: ^2.0.0
   archive: ^3.1.2
   background_fetch: ^1.0.1
   cached_network_image: ^3.0.0
   chewie: ^1.0.0
-  computer: ^1.0.2
-  confetti: ^0.5.5
+  computer: ^2.0.0
+  confetti: ^0.6.0
   connectivity: ^3.0.3
   crisp:
     git: "https://github.com/kcrebound/flutter-crisp.git"
@@ -53,7 +53,7 @@ dependencies:
   flutter_sodium: ^0.2.0
   flutter_typeahead: ^3.2.0
   flutter_user_agent: ^1.2.2
-  flutter_windowmanager: ^0.0.2
+  flutter_windowmanager: ^0.2.0
   fluttercontactpicker: ^4.4.0
   fluttertoast: ^8.0.6
   google_nav_bar: ^5.0.5
@@ -72,7 +72,7 @@ dependencies:
   move_to_background: ^1.0.2
   open_file: ^3.2.1
   package_info_plus: ^1.0.1
-  page_transition: ^1.1.7+2
+  page_transition: ^2.0.2
   path_provider: ^2.0.1
   pedantic: ^1.9.2
   photo_manager:
@@ -81,7 +81,7 @@ dependencies:
   pie_chart:
     git: "https://github.com/apgapg/pie_chart.git"
   pinput: ^1.2.0
-  provider: ^3.1.0
+  provider: ^6.0.0
   quiver: ^3.0.1
   receive_sharing_intent: ^1.4.5
   scrollable_positioned_list: ^0.1.10


### PR DESCRIPTION
## Description
Upgrading packages to their null safe version.
Pending Packages:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/254676/133915364-80f27ee4-715c-41c2-96ff-9aaebc0e9fd5.png">

Only [expansion_card](https://pub.dev/packages/expansion_card), [flutter_user_agent](https://pub.dev/packages/flutter_user_agent) & [super_logging](https://pub.dev/packages/super_logging) don't have a null-safe version. `flutter_user_agent` is discontinued, so will replace it. Will also explore options for expansion_card and super_logging.

## Test Plan
* Tested basic functionality of the app. 
* Went through readme of packages to verify no breaking changes is impacting frame app.