### PR TITLE
Android: Support sharing videos to ente

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,18 @@
                 <data android:mimeType="image/*" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/ui/video_widget.dart
+++ b/lib/ui/video_widget.dart
@@ -46,7 +46,7 @@ class _VideoWidgetState extends State<VideoWidget> {
     } else if (widget.file.isSharedMediaToAppSandbox()) {
       final localFile = io.File(getSharedMediaFilePath(widget.file));
       if (localFile.existsSync()) {
-        _logger.info("loading from local source");
+        _logger.fine("loading from app cache");
         _setVideoPlayerController(file: localFile);
       } else if (widget.file.uploadedFileID != null) {
         _loadNetworkVideo();
@@ -72,7 +72,6 @@ class _VideoWidgetState extends State<VideoWidget> {
       progressCallback: (count, total) {
         if (mounted) {
           setState(() {
-            _logger.info("calling set state");
             _progress = count / total;
             if (_progress == 1) {
               showToast("decrypting video...", toastLength: Toast.LENGTH_SHORT);

--- a/lib/utils/file_uploader_util.dart
+++ b/lib/utils/file_uploader_util.dart
@@ -148,7 +148,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(ente.File file) async {
   } catch (e, s) {
     _logger.severe("failed to generate thumbnail", e, s);
     throw InvalidFileError(
-        "thumbnail generated failed for fileType: ${file.fileType.toString()}");
+        "thumbnail generation failed for fileType: ${file.fileType.toString()}");
   }
 }
 

--- a/lib/utils/file_uploader_util.dart
+++ b/lib/utils/file_uploader_util.dart
@@ -163,7 +163,7 @@ Future<Uint8List> getThumbnailFromInAppCacheFile(ente.File file) async {
       imageFormat: ImageFormat.JPEG,
       thumbnailPath: (await getTemporaryDirectory()).path,
       maxWidth: kThumbnailLargeSize,
-      quality: 100,
+      quality: 80,
     );
     localFile = io.File(thumbnailFilePath);
   }

--- a/lib/utils/share_util.dart
+++ b/lib/utils/share_util.dart
@@ -40,6 +40,12 @@ Future<List<File>> convertIncomingSharedMediaToFile(
     List<SharedMediaFile> sharedMedia, int collectionID) async {
   List<File> localFiles = [];
   for (var media in sharedMedia) {
+    if (!(media.type == SharedMediaType.IMAGE ||
+        media.type == SharedMediaType.VIDEO)) {
+      _logger.warning(
+          "ignore unsupported file type ${media.type.toString()} path: ${media.path}");
+      continue;
+    }
     var enteFile = File();
     // fileName: img_x.jpg
     enteFile.title = basename(media.path);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1091,6 +1091,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  video_thumbnail:
+    dependency: "direct main"
+    description:
+      name: video_thumbnail
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.3"
   visibility_detector:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,7 @@ dependencies:
   url_launcher: ^6.0.3
   uuid: ^3.0.4
   video_player: ^2.0.0
+  video_thumbnail: ^0.4.3
   visibility_detector: ^0.2.0
   wallpaper_manager_flutter: ^0.0.2
 


### PR DESCRIPTION
## Description
Title ^
## Test Plan
Verified that
 - we are able to upload mix of both images & videos
 - `backup` to ente is visible when user tries to share video
 -  Apart from video or image, any other file type is silently ignored.
