### PR TITLE
specify 5000ms as connect timeout

### DIFF
--- a/lib/core/network.dart
+++ b/lib/core/network.dart
@@ -4,13 +4,14 @@ import 'package:dio/dio.dart';
 import 'package:flutter_user_agent/flutter_user_agent.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+int kConnectTimeout = 5000;
 class Network {
   Dio _dio;
 
   Future<void> init() async {
     await FlutterUserAgent.init();
     final packageInfo = await PackageInfo.fromPlatform();
-    _dio = Dio(BaseOptions(headers: {
+    _dio = Dio(BaseOptions(connectTimeout: kConnectTimeout, headers: {
       HttpHeaders.userAgentHeader: FlutterUserAgent.userAgent,
       'X-Client-Version': packageInfo.version,
       'X-Client-Package': packageInfo.packageName,


### PR DESCRIPTION
## Description
This will ensure that UI dialog gets dismissed within reasonable time when the client is not able to connect to the API server.
## Test Plan
Tested locally on flaky 5G Wifi network
