### PR TITLE
DB: delete duplicate files in collection & unique index to avoid this in future

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -258,17 +258,20 @@ class FilesDB {
       '''
       DELETE from $table where ($columnCollectionID, $columnUploadedFileID) IN 
       (SELECT $columnCollectionID, $columnUploadedFileID from $table WHERE 
-        $columnCollectionID is not NULL and $columnUploadedFileID is NOT NULL
+        $columnCollectionID is not NULL AND $columnUploadedFileID is NOT NULL
+        AND $columnCollectionID != -1 AND $columnUploadedFileID  != -1
         GROUP BY $columnCollectionID, $columnUploadedFileID HAVING count(*) > 1)
       AND  ($columnCollectionID, $columnUploadedFileID,$columnGeneratedID) NOT IN 
       (SELECT $columnCollectionID, $columnUploadedFileID, max($columnGeneratedID)
-       from $table WHERE $columnCollectionID is not NULL 
-       AND $columnUploadedFileID is NOT NULL GROUP BY 
+       from $table WHERE 
+       $columnCollectionID is not NULL AND $columnUploadedFileID is NOT NULL
+       AND $columnCollectionID != -1 AND $columnUploadedFileID  != -1 GROUP BY 
        $columnCollectionID, $columnUploadedFileID HAVING count(*) > 1);
       ''',
       '''
       CREATE UNIQUE INDEX cid_uid ON $table ($columnCollectionID, $columnUploadedFileID) 
-      WHERE $columnCollectionID is not NULL AND $columnUploadedFileID is not NULL;
+      WHERE $columnCollectionID is not NULL AND $columnUploadedFileID is not NULL
+      AND $columnCollectionID != -1 AND $columnUploadedFileID  != -1;
       '''
     ];
   }

--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -68,6 +68,7 @@ class FilesDB {
     ...addIndices(),
     ...addMetadataColumns(),
     ...addMagicMetadataColumns(),
+    ...addUniqueConstraintOnCollectionFiles(),
   ];
 
   final dbConfig = MigrationConfig(
@@ -248,6 +249,26 @@ class FilesDB {
       ''',
       '''
         ALTER TABLE $table ADD COLUMN $columnMMdVisibility INTEGER DEFAULT $kVisibilityVisible;
+      '''
+    ];
+  }
+
+  static List<String> addUniqueConstraintOnCollectionFiles() {
+    return [
+      '''
+      DELETE from $table where ($columnCollectionID, $columnUploadedFileID) IN 
+      (SELECT $columnCollectionID, $columnUploadedFileID from $table WHERE 
+        $columnCollectionID is not NULL and $columnUploadedFileID is NOT NULL
+        GROUP BY $columnCollectionID, $columnUploadedFileID HAVING count(*) > 1)
+      AND  ($columnCollectionID, $columnUploadedFileID,$columnGeneratedID) NOT IN 
+      (SELECT $columnCollectionID, $columnUploadedFileID, max($columnGeneratedID)
+       from $table WHERE $columnCollectionID is not NULL 
+       AND $columnUploadedFileID is NOT NULL GROUP BY 
+       $columnCollectionID, $columnUploadedFileID HAVING count(*) > 1);
+      ''',
+      '''
+      CREATE UNIQUE INDEX cid_uid ON $table ($columnCollectionID, $columnUploadedFileID) 
+      WHERE $columnCollectionID is not NULL AND $columnUploadedFileID is not NULL;
       '''
     ];
   }


### PR DESCRIPTION
Title ^

## Description

## Test Plan
- Installed old version of the app and verified that duplicates entries where showing in a single collection
- Migrated to this version and verified all duplicate entries were gone.
- Verified that the magic metadata version was synced correctly.
