### PR TITLE
Fix handling of stripe subscription

### DIFF
--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -85,17 +85,21 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
   }
 
   FutureOr onWebPaymentGoBack(dynamic value) async {
-    if (widget.isOnboarding) {
+    // refresh subscription
+    await _dialog.show();
+    try {
+      await _fetchSub();
+    } catch (e) {
+      showToast("failed to refresh subscription");
+    }
+    await _dialog.hide();
+
+    // verify user has subscribed before redirecting to main page
+    if (widget.isOnboarding &&
+        _currentSubscription != null &&
+        _currentSubscription.isValid() &&
+        _currentSubscription.productID != kFreeProductID) {
       Navigator.of(context).popUntil((route) => route.isFirst);
-    } else {
-      // refresh subscription
-      await _dialog.show();
-      try {
-        await _fetchSub();
-      } catch (e) {
-        showToast("failed to refresh subscription");
-      }
-      await _dialog.hide();
     }
   }
 

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -152,7 +152,8 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
       widgets.add(SubFaqWidget());
     }
 
-    if (_currentSubscription.paymentProvider == kStripe) {
+    // only active subscription can be renewed/canceled
+    if (_hasActiveSubscription && _isStripeSubscriber) {
       widgets.add(_stripeRenewOrCancelButton());
     }
 
@@ -301,7 +302,9 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
               if (isActive) {
                 return;
               }
-              if (_currentSubscription.paymentProvider != kStripe &&
+              // prompt user to cancel their active subscription form other
+              // payment providers
+              if (!_isStripeSubscriber &&
                   _hasActiveSubscription &&
                   _currentSubscription.productID != kFreeProductID) {
                 showErrorDialog(context, "sorry",

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -154,7 +154,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
       widgets.add(SubFaqWidget());
     }
 
-    if (_hasActiveSubscription && _isActiveStripeSubscriber) {
+    if (_currentSubscription.paymentProvider == kStripe) {
       widgets.add(_stripeRenewOrCancelButton());
     }
 

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -44,7 +44,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
   FreePlan _freePlan;
   List<BillingPlan> _plans = [];
   bool _hasLoadedData = false;
-  bool _isActiveStripeSubscriber;
+  bool _isStripeSubscriber = false;
   bool _showYearlyPlan = false;
 
   @override
@@ -59,9 +59,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
       _currentSubscription = subscription;
       _showYearlyPlan = _currentSubscription.isYearlyPlan();
       _hasActiveSubscription = _currentSubscription.isValid();
-      _isActiveStripeSubscriber =
-          _currentSubscription.paymentProvider == kStripe &&
-              _currentSubscription.isValid();
+      _isStripeSubscriber = _currentSubscription.paymentProvider == kStripe;
       _usageFuture = _billingService.fetchUsage();
       return _filterStripeForUI().then((value) {
         _hasLoadedData = true;
@@ -158,8 +156,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
       widgets.add(_stripeRenewOrCancelButton());
     }
 
-    if (_hasActiveSubscription &&
-        _currentSubscription.productID != kFreeProductID) {
+    if (_currentSubscription.productID != kFreeProductID) {
       widgets.addAll([
         Align(
           alignment: Alignment.center,
@@ -189,11 +186,11 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
                 children: [
                   RichText(
                     text: TextSpan(
-                      text: !_isActiveStripeSubscriber
+                      text: !_isStripeSubscriber
                           ? "visit ${_currentSubscription.paymentProvider} to manage your subscription"
                           : "payment details",
                       style: TextStyle(
-                        color: _isActiveStripeSubscriber
+                        color: _isStripeSubscriber
                             ? Colors.blue
                             : Colors.white,
                         fontFamily: 'Ubuntu',
@@ -322,7 +319,7 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
                 }
               }
               String stripPurChaseAction = 'buy';
-              if (_isActiveStripeSubscriber) {
+              if (_isStripeSubscriber && _hasActiveSubscription) {
                 // confirm if user wants to change plan or not
                 var result = await showChoiceDialog(
                     context,

--- a/lib/ui/payment/stripe_subscription_page.dart
+++ b/lib/ui/payment/stripe_subscription_page.dart
@@ -304,7 +304,8 @@ class _StripeSubscriptionPageState extends State<StripeSubscriptionPage> {
               if (isActive) {
                 return;
               }
-              if (!_isActiveStripeSubscriber &&
+              if (_currentSubscription.paymentProvider != kStripe &&
+                  _hasActiveSubscription &&
                   _currentSubscription.productID != kFreeProductID) {
                 showErrorDialog(context, "sorry",
                     "please cancel your existing subscription from ${_currentSubscription.paymentProvider} first");


### PR DESCRIPTION
## Description
1. Stay on the stripe plan selection page during the onboarding step unless user  successfully subscribe via stripe or they click on `continue on free plan button` button.

2. Show payment details button even if current plan has expired

3. Bug fix: Show prompt to cancel non-stripe subscription only. This bug was stopping users from re-subscribing after the expiry of current stripe plan.

## Test Plan
Tested locally.
