### PR TITLE
Fix gallery import by removing filter on creationTime

### DIFF
--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -111,6 +111,7 @@ class LocalSyncService {
     if (!_prefs.containsKey(kHasCompletedFirstImportKey) ||
         !_prefs.getBool(kHasCompletedFirstImportKey)) {
       await _prefs.setBool(kHasCompletedFirstImportKey, true);
+      _logger.fine("first gallery import finished");
       Bus.instance
           .fire(SyncStatusUpdate(SyncStatus.completed_first_gallery_import));
     }

--- a/lib/utils/file_sync_util.dart
+++ b/lib/utils/file_sync_util.dart
@@ -104,10 +104,7 @@ Future<List<AssetPathEntity>> _getGalleryList(
   final filterOptionGroup = FilterOptionGroup();
   filterOptionGroup.setOption(AssetType.image, FilterOption(needTitle: true));
   filterOptionGroup.setOption(AssetType.video, FilterOption(needTitle: true));
-  filterOptionGroup.createTimeCond = DateTimeCond(
-    min: DateTime.fromMicrosecondsSinceEpoch(fromTime),
-    max: DateTime.fromMicrosecondsSinceEpoch(toTime),
-  );
+
   filterOptionGroup.updateTimeCond = DateTimeCond(
     min: DateTime.fromMicrosecondsSinceEpoch(fromTime),
     max: DateTime.fromMicrosecondsSinceEpoch(toTime),


### PR DESCRIPTION
## Description
The filter conditions on both creation time & update time breaks the initial update because there can be files where the creation time & update time won't fall under same window.
Due to this bug, during first import flow, the client fails to import files in the app's db before firing first Sync completed event. 

## Test Plan
- Verified the bug & fix on iOS simulator (with stocked images)
- Verified that any file which is edited using Photo app is updated on Ente during next sync.

[1]  <img width="667" alt="image" src="https://user-images.githubusercontent.com/254676/135281446-bcb352f1-8648-4f4f-b190-f19b6a2bb7c4.png">

