### PR TITLE
Surface errors from the diff fetcher

### DIFF
--- a/lib/utils/diff_fetcher.dart
+++ b/lib/utils/diff_fetcher.dart
@@ -19,18 +19,17 @@ class DiffFetcher {
 
   Future<Diff> getEncryptedFilesDiff(
       int collectionID, int sinceTime, int limit) async {
-    return _dio.get(
-      Configuration.instance.getHttpEndpoint() + "/collections/diff",
-      options:
-          Options(headers: {"X-Auth-Token": Configuration.instance.getToken()}),
-      queryParameters: {
-        "collectionID": collectionID,
-        "sinceTime": sinceTime,
-        "limit": limit,
-      },
-    ).catchError((e) {
-      _logger.severe(e);
-    }).then((response) async {
+    try {
+      final response = await _dio.get(
+        Configuration.instance.getHttpEndpoint() + "/collections/diffwa",
+        options: Options(
+            headers: {"X-Auth-Token": Configuration.instance.getToken()}),
+        queryParameters: {
+          "collectionID": collectionID,
+          "sinceTime": sinceTime,
+          "limit": limit,
+        },
+      );
       final files = <File>[];
       if (response != null) {
         Bus.instance.fire(RemoteSyncEvent(true));
@@ -101,7 +100,10 @@ class DiffFetcher {
         Bus.instance.fire(RemoteSyncEvent(false));
         return Diff(<File>[], <File>[], 0);
       }
-    });
+    } catch (e, s) {
+      _logger.severe(e, s);
+      rethrow;
+    }
   }
 }
 

--- a/lib/utils/diff_fetcher.dart
+++ b/lib/utils/diff_fetcher.dart
@@ -21,7 +21,7 @@ class DiffFetcher {
       int collectionID, int sinceTime, int limit) async {
     try {
       final response = await _dio.get(
-        Configuration.instance.getHttpEndpoint() + "/collections/diffwa",
+        Configuration.instance.getHttpEndpoint() + "/collections/diff",
         options: Options(
             headers: {"X-Auth-Token": Configuration.instance.getToken()}),
         queryParameters: {


### PR DESCRIPTION
## Description
Bubble up errors during diff fetch to break the sync flow.

## Test Plan
- [x] Tested manually with a broken endpoint to ensure that the collection was not marked as synced