### PR TITLE
Improvements to the memory widget

### DIFF
--- a/lib/services/memories_service.dart
+++ b/lib/services/memories_service.dart
@@ -88,7 +88,6 @@ class MemoriesService extends ChangeNotifier {
   }
 
   Future markMemoryAsSeen(Memory memory) async {
-    _logger.info("Marking memory " + memory.file.title + " as seen");
     memory.markSeen();
     await _memoriesDB.markMemoryAsSeen(
         memory, DateTime.now().microsecondsSinceEpoch);

--- a/lib/ui/blurred_file_backdrop.dart
+++ b/lib/ui/blurred_file_backdrop.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:animate_do/animate_do.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:photos/models/file.dart';
@@ -13,21 +12,13 @@ class BlurredFileBackdrop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FadeIn(
-      duration: Duration(milliseconds: 500),
-      child: Stack(children: [
-        ThumbnailWidget(
-          file,
-          fit: BoxFit.cover,
-          key: Key("memory_backdrop" + file.tag()),
-        ),
-        BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 64.0, sigmaY: 64.0),
-          child: Container(
-            decoration: BoxDecoration(color: Colors.white.withOpacity(0.0)),
-          ),
-        ),
-      ]),
+    return ImageFiltered(
+      imageFilter: ImageFilter.blur(sigmaX: 64.0, sigmaY: 64.0),
+      child: ThumbnailWidget(
+        file,
+        fit: BoxFit.cover,
+        key: Key("memory_backdrop" + file.tag()),
+      ),
     );
   }
 }

--- a/lib/ui/detail_page.dart
+++ b/lib/ui/detail_page.dart
@@ -7,14 +7,11 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/errors.dart';
 import 'package:photos/models/file.dart';
-import 'package:photos/models/file_type.dart';
 import 'package:photos/ui/fading_app_bar.dart';
 import 'package:photos/ui/fading_bottom_bar.dart';
+import 'package:photos/ui/file_widget.dart';
 import 'package:photos/ui/gallery.dart';
 import 'package:photos/ui/image_editor_page.dart';
-import 'package:photos/ui/video_widget.dart';
-import 'package:photos/ui/zoomable_live_image.dart';
-import 'package:photos/ui/zoomable_image.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/file_util.dart';
 import 'package:photos/utils/navigation_util.dart';
@@ -135,40 +132,20 @@ class _DetailPageState extends State<DetailPage> {
     return PageView.builder(
       itemBuilder: (context, index) {
         final file = _files[index];
-        Widget content;
-        if (file.fileType == FileType.image) {
-          content = ZoomableImage(
-            file,
-            shouldDisableScroll: (value) {
-              setState(() {
-                _shouldDisableScroll = value;
-              });
-            },
-            tagPrefix: widget.config.tagPrefix,
-          );
-        } else if (file.fileType == FileType.livePhoto) {
-          content = ZoomableLiveImage(
-            file,
-            shouldDisableScroll: (value) {
-              setState(() {
-                _shouldDisableScroll = value;
-              });
-            },
-            tagPrefix: widget.config.tagPrefix,
-          );
-        } else if (file.fileType == FileType.video) {
-          content = VideoWidget(
-            file,
-            autoPlay: !_hasPageChanged, // Autoplay if it was opened directly
-            tagPrefix: widget.config.tagPrefix,
-            playbackCallback: (isPlaying) {
-              _shouldHideAppBar = isPlaying;
-              _toggleFullScreen();
-            },
-          );
-        } else {
-          content = Icon(Icons.error);
-        }
+        Widget content = FileWidget(
+          file,
+          autoPlay: !_hasPageChanged,
+          tagPrefix: widget.config.tagPrefix,
+          shouldDisableScroll: (value) {
+            setState(() {
+              _shouldDisableScroll = value;
+            });
+          },
+          playbackCallback: (isPlaying) {
+            _shouldHideAppBar = isPlaying;
+            _toggleFullScreen();
+          },
+        );
         _preloadFiles(index);
         return GestureDetector(
           onTap: () {

--- a/lib/ui/fading_app_bar.dart
+++ b/lib/ui/fading_app_bar.dart
@@ -14,6 +14,7 @@ import 'package:photos/models/file_type.dart';
 import 'package:photos/services/favorites_service.dart';
 import 'package:photos/services/local_sync_service.dart';
 import 'package:photos/ui/custom_app_bar.dart';
+import 'package:photos/ui/progress_dialog.dart';
 import 'package:photos/utils/date_time_util.dart';
 import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/dialog_util.dart';
@@ -61,7 +62,7 @@ class FadingAppBarState extends State<FadingAppBar> {
                 Colors.black.withOpacity(0.5),
                 Colors.transparent,
               ],
-              stops: [0, 0.2, 1],
+              stops: const [0, 0.2, 1],
             ),
           ),
           child: _buildAppBar(),
@@ -80,9 +81,11 @@ class FadingAppBarState extends State<FadingAppBar> {
   }
 
   void show() {
-    setState(() {
-      _shouldHide = false;
-    });
+    if (mounted) {
+      setState(() {
+        _shouldHide = false;
+      });
+    }
   }
 
   AppBar _buildAppBar() {
@@ -176,7 +179,7 @@ class FadingAppBarState extends State<FadingAppBar> {
         bool hasError = false;
         if (isLiked) {
           final shouldBlockUser = file.uploadedFileID == null;
-          var dialog;
+          ProgressDialog dialog;
           if (shouldBlockUser) {
             dialog = createProgressDialog(context, "adding to favorites...");
             await dialog.show();

--- a/lib/ui/file_widget.dart
+++ b/lib/ui/file_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:photos/models/file.dart';
+import 'package:photos/models/file_type.dart';
+import 'package:photos/ui/video_widget.dart';
+import 'package:photos/ui/zoomable_image.dart';
+import 'package:photos/ui/zoomable_live_image.dart';
+
+class FileWidget extends StatelessWidget {
+  final File file;
+  final String tagPrefix;
+  final Function(bool) shouldDisableScroll;
+  final Function(bool) playbackCallback;
+  final BoxDecoration backgroundDecoration;
+  final bool autoPlay;
+
+  const FileWidget(
+    this.file, {
+    this.autoPlay,
+    this.shouldDisableScroll,
+    this.playbackCallback,
+    this.tagPrefix,
+    this.backgroundDecoration,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (file.fileType == FileType.image) {
+      return ZoomableImage(
+        file,
+        shouldDisableScroll: shouldDisableScroll,
+        tagPrefix: tagPrefix,
+        backgroundDecoration: backgroundDecoration,
+      );
+    } else if (file.fileType == FileType.livePhoto) {
+      return ZoomableLiveImage(
+        file,
+        shouldDisableScroll: shouldDisableScroll,
+        tagPrefix: tagPrefix,
+        backgroundDecoration: backgroundDecoration,
+      );
+    } else if (file.fileType == FileType.video) {
+      return VideoWidget(
+        file,
+        autoPlay: autoPlay, // Autoplay if it was opened directly
+        tagPrefix: tagPrefix,
+        playbackCallback: playbackCallback,
+      );
+    } else {
+      return Icon(Icons.error);
+    }
+  }
+}

--- a/lib/ui/memories_widget.dart
+++ b/lib/ui/memories_widget.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
-import 'package:photos/models/file.dart';
-import 'package:photos/models/file_type.dart';
 import 'package:photos/models/memory.dart';
 import 'package:photos/services/memories_service.dart';
 import 'package:photos/ui/blurred_file_backdrop.dart';
 import 'package:photos/ui/extents_page_view.dart';
+import 'package:photos/ui/file_widget.dart';
 import 'package:photos/ui/thumbnail_widget.dart';
-import 'package:photos/ui/video_widget.dart';
-import 'package:photos/ui/zoomable_image.dart';
 import 'package:photos/utils/date_time_util.dart';
 import 'package:photos/utils/file_util.dart';
 import 'package:photos/utils/navigation_util.dart';
@@ -223,6 +220,7 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
   int _index = 0;
   double _opacity = 1;
   PageController _pageController;
+  bool _shouldDisableScroll = false;
 
   @override
   void initState() {
@@ -318,7 +316,19 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
           preloadFile(nextFile);
         }
         final file = widget.memories[index].file;
-        return MemoryItem(file);
+        return FileWidget(
+          file,
+          autoPlay: false,
+          tagPrefix: "memories",
+          shouldDisableScroll: (value) {
+            setState(() {
+              _shouldDisableScroll = value;
+            });
+          },
+          backgroundDecoration: BoxDecoration(
+            color: Colors.transparent,
+          ),
+        );
       },
       itemCount: widget.memories.length,
       controller: _pageController,
@@ -329,32 +339,9 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
           _index = index;
         });
       },
+      physics: _shouldDisableScroll
+          ? NeverScrollableScrollPhysics()
+          : PageScrollPhysics(),
     );
-  }
-}
-
-class MemoryItem extends StatelessWidget {
-  final File file;
-  const MemoryItem(this.file, {Key key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final view = file.fileType == FileType.image
-        ? ZoomableImage(
-            file,
-            tagPrefix: "memories",
-            backgroundDecoration: BoxDecoration(
-              color: Colors.transparent,
-            ),
-          )
-        : VideoWidget(
-            file,
-            tagPrefix: "memories",
-            autoPlay: false,
-          );
-    return Stack(children: [
-      // BlurredFileBackdrop(file),
-      view,
-    ]);
   }
 }

--- a/lib/ui/memories_widget.dart
+++ b/lib/ui/memories_widget.dart
@@ -154,16 +154,26 @@ class _MemoryWidgetState extends State<MemoryWidget> {
     );
   }
 
+  // Returns either the first unseen memory or the memory that succeeds the
+  // last seen memory
   int _getNextMemoryIndex() {
     int lastSeenIndex = 0;
-    for (var index = widget.memories.length - 1; index >= 0; index--) {
-      if (!widget.memories[index].isSeen()) {
-        lastSeenIndex = index;
+    int lastSeenTimestamp = 0;
+    for (var index = 0; index < widget.memories.length; index++) {
+      final memory = widget.memories[index];
+      if (!memory.isSeen()) {
+        return index;
       } else {
-        break;
+        if (memory.seenTime() > lastSeenTimestamp) {
+          lastSeenIndex = index;
+          lastSeenTimestamp = memory.seenTime();
+        }
       }
     }
-    return lastSeenIndex;
+    if (lastSeenIndex == widget.memories.length - 1) {
+      return 0;
+    }
+    return lastSeenIndex + 1;
   }
 
   String _getTitle(Memory memory) {

--- a/lib/ui/zoomable_image.dart
+++ b/lib/ui/zoomable_image.dart
@@ -131,7 +131,7 @@ class _ZoomableImageState extends State<ZoomableImage>
       _loadingLargeThumbnail = true;
       getThumbnailFromLocal(_photo, size: kThumbnailLargeSize, quality: 100)
           .then((cachedThumbnail) {
-        if(cachedThumbnail != null) {
+        if (cachedThumbnail != null) {
           _onLargeThumbnailLoaded(Image.memory(cachedThumbnail).image, context);
         }
       });


### PR DESCRIPTION
## Description
^ Title + commit messages

## Test Plan
- [x] Verified that video playback now works within memories
- [x] Verified that swipe is disabled once an image is zoomed in
- [x] Verified that broken UI due to `'package:flutter/src/widgets/heroes.dart': Failed assertion: line 614 pos 14: 'overlayEntry != null': is not true` has been fixed by https://github.com/ente-io/frame/commit/242bd9ca5a75e1765d57f39174cd3f5eccc3394e.