### PR TITLE
Fix the bug in Gallery where we were wrongly rendering files that belonged to the preceding/succeeding day

### DIFF
--- a/lib/ui/detail_page.dart
+++ b/lib/ui/detail_page.dart
@@ -79,7 +79,9 @@ class _DetailPageState extends State<DetailPage> {
 
   @override
   void initState() {
-    _files = widget.config.files;
+    _files = [
+      ...widget.config.files
+    ]; // Make a copy since we append preceding and succeeding entries to this
     _selectedIndex = widget.config.selectedIndex;
     _preloadEntries();
     super.initState();

--- a/lib/ui/huge_listview/lazy_loading_gallery.dart
+++ b/lib/ui/huge_listview/lazy_loading_gallery.dart
@@ -323,7 +323,7 @@ class _LazyLoadingGridViewState extends State<LazyLoadingGridView> {
 
   void _routeToDetailPage(File file, BuildContext context) {
     final page = DetailPage(DetailPageConfiguration(
-      widget.files,
+      List.unmodifiable(widget.files),
       widget.asyncLoader,
       widget.files.indexOf(file),
       widget.tag,


### PR DESCRIPTION
## Description

### The Bug
This was a result of an [optimization](https://github.com/ente-io/frame/blob/master/lib/ui/detail_page.dart#L212-L245) within `DetailPage` that prefetches files that were
- created before the first file within the sub-gallery and/or 
- created after the last file within the sub-gallery

These fetched files were getting added to the `files` object that is passed to the `DetailPage` by the parent widget (in this case `LazyLoadingGallery`).

On exiting the `DetailPage` after such prefetches, this resulted in the gallery displaying entries that did not belong to the day it was responsible for. 

### The Fix

We will now force the `DetailPage` to maintain a copy of the files that are passed to it, instead of modifying the one that was passed down to it by the parent widget.

## Test Plan

- [x] Verified that the bug is no longer reproducible
