### PR TITLE
Fix Thumbnail load for files with localID but corresponding local file is misisng/deleted.

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -433,7 +433,8 @@ class FilesDB {
       limit: limit,
     );
     final files = _convertToFiles(results);
-    return FileLoadResult(files, files.length == limit);
+    List<File> deduplicatedFiles = _deduplicatedFiles(files);
+    return FileLoadResult(deduplicatedFiles, files.length == limit);
   }
 
   Future<FileLoadResult> getImportantFiles(

--- a/lib/db/trash_db.dart
+++ b/lib/db/trash_db.dart
@@ -156,6 +156,16 @@ class TrashDB {
     );
   }
 
+  Future<int> update(TrashFile file) async {
+    final db = await instance.database;
+    return await db.update(
+      tableName,
+      _getRowForTrash(file),
+      where: '$columnUploadedFileID = ?',
+      whereArgs: [file.uploadedFileID],
+    );
+  }
+
   Future<FileLoadResult> getTrashedFiles(int startTime, int endTime,
       {int limit, bool asc}) async {
     final db = await instance.database;

--- a/lib/ui/thumbnail_widget.dart
+++ b/lib/ui/thumbnail_widget.dart
@@ -7,6 +7,7 @@ import 'package:photos/core/constants.dart';
 import 'package:photos/core/errors.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/files_db.dart';
+import 'package:photos/db/trash_db.dart';
 import 'package:photos/events/local_photos_updated_event.dart';
 import 'package:photos/models/file.dart';
 import 'package:photos/models/file_type.dart';
@@ -214,9 +215,11 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     getThumbnailFromLocal(widget.file).then((thumbData) async {
       if (thumbData == null) {
         if (widget.file.uploadedFileID != null) {
-          if (widget.file is! TrashFile) {
-            _logger.fine("Removing localID reference for " + widget.file.tag());
-            widget.file.localID = null;
+          _logger.fine("Removing localID reference for " + widget.file.tag());
+          widget.file.localID = null;
+          if (widget.file is TrashFile) {
+            TrashDB.instance.update(widget.file);
+          } else {
             FilesDB.instance.update(widget.file);
           }
           _loadNetworkImage();

--- a/lib/ui/thumbnail_widget.dart
+++ b/lib/ui/thumbnail_widget.dart
@@ -104,8 +104,10 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   );
 
   bool _hasLoadedThumbnail = false;
-  bool _isLoadingThumbnail = false;
-  bool _encounteredErrorLoadingThumbnail = false;
+  bool _isLoadingLocalThumbnail = false;
+  bool _errorLoadingLocalThumbnail = false;
+  bool _isLoadingRemoteThumbnail = false;
+  bool _errorLoadingRemoteThumbnail = false;
   ImageProvider _imageProvider;
 
   @override
@@ -188,9 +190,9 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
 
   void _loadLocalImage(BuildContext context) {
     if (!_hasLoadedThumbnail &&
-        !_encounteredErrorLoadingThumbnail &&
-        !_isLoadingThumbnail) {
-      _isLoadingThumbnail = true;
+        !_errorLoadingLocalThumbnail &&
+        !_isLoadingLocalThumbnail) {
+      _isLoadingLocalThumbnail = true;
       final cachedSmallThumbnail =
           ThumbnailLruCache.get(widget.file, kThumbnailSmallSize);
       if (cachedSmallThumbnail != null) {
@@ -239,15 +241,15 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       ThumbnailLruCache.put(widget.file, thumbData, kThumbnailSmallSize);
     }).catchError((e) {
       _logger.warning("Could not load image: ", e);
-      _encounteredErrorLoadingThumbnail = true;
+      _errorLoadingLocalThumbnail = true;
     });
   }
 
   void _loadNetworkImage() {
     if (!_hasLoadedThumbnail &&
-        !_encounteredErrorLoadingThumbnail &&
-        !_isLoadingThumbnail) {
-      _isLoadingThumbnail = true;
+        !_errorLoadingRemoteThumbnail &&
+        !_isLoadingRemoteThumbnail) {
+      _isLoadingRemoteThumbnail = true;
       final cachedThumbnail = ThumbnailLruCache.get(widget.file);
       if (cachedThumbnail != null) {
         _imageProvider = Image.memory(cachedThumbnail).image;
@@ -283,7 +285,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
         }
       } else {
         _logger.severe("Could not load image " + widget.file.toString(), e);
-        _encounteredErrorLoadingThumbnail = true;
+        _errorLoadingRemoteThumbnail = true;
       }
     }
   }
@@ -306,8 +308,8 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
 
   void _reset() {
     _hasLoadedThumbnail = false;
-    _isLoadingThumbnail = false;
-    _encounteredErrorLoadingThumbnail = false;
+    _isLoadingLocalThumbnail = false;
+    _errorLoadingLocalThumbnail = false;
     _imageProvider = null;
   }
 }

--- a/lib/ui/thumbnail_widget.dart
+++ b/lib/ui/thumbnail_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'dart:math';
-import 'package:logging/logging.dart';
 import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
 import 'package:photos/core/cache/thumbnail_cache.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/errors.dart';

--- a/lib/ui/thumbnail_widget.dart
+++ b/lib/ui/thumbnail_widget.dart
@@ -309,7 +309,9 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   void _reset() {
     _hasLoadedThumbnail = false;
     _isLoadingLocalThumbnail = false;
+    _isLoadingRemoteThumbnail = false;
     _errorLoadingLocalThumbnail = false;
+    _errorLoadingRemoteThumbnail = false;
     _imageProvider = null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.3.41+251
+version: 0.3.42+252
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description

- Trash Bug: When file is missing locally, we were not resetting the localID to null
- Widget Bug: When the file is deleted from locally, then the first thumbnail load always fails as `_loadNetworkImage` does not load image from remote because `_isLoadingThumbnail` was set to true.

## Test Plan
 - Tested locally and verified that thumbnails are loading as expected. 
