### PR TITLE
Fix missing files

### DIFF
--- a/lib/utils/file_sync_util.dart
+++ b/lib/utils/file_sync_util.dart
@@ -6,7 +6,7 @@ import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/models/file.dart';
 
 final _logger = Logger("FileSyncUtil");
-
+final ignoreSizeConstraint = SizeConstraint(ignoreSize: true);
 Future<List<File>> getDeviceFiles(
     int fromTime, int toTime, Computer computer) async {
   final pathEntities = await _getGalleryList(fromTime, toTime);
@@ -28,7 +28,10 @@ Future<List<File>> getDeviceFiles(
 }
 
 Future<List<LocalAsset>> getAllLocalAssets() async {
-  final filterOptionGroup = FilterOptionGroup();
+  final filterOptionGroup = FilterOptionGroup(
+      imageOption: FilterOption(sizeConstraint: ignoreSizeConstraint),
+      videoOption: FilterOption(sizeConstraint: ignoreSizeConstraint),
+      createTimeCond: DateTimeCond.def().copyWith(ignore: true));
   final assetPaths = await PhotoManager.getAssetPathList(
     hasAll: true,
     type: RequestType.common,
@@ -102,8 +105,10 @@ Future<List<File>> _convertToFiles(
 Future<List<AssetPathEntity>> _getGalleryList(
     final int fromTime, final int toTime) async {
   final filterOptionGroup = FilterOptionGroup();
-  filterOptionGroup.setOption(AssetType.image, FilterOption(needTitle: true));
-  filterOptionGroup.setOption(AssetType.video, FilterOption(needTitle: true));
+  filterOptionGroup.setOption(AssetType.image,
+      FilterOption(needTitle: true, sizeConstraint: ignoreSizeConstraint));
+  filterOptionGroup.setOption(AssetType.video,
+      FilterOption(needTitle: true, sizeConstraint: ignoreSizeConstraint));
 
   filterOptionGroup.updateTimeCond = DateTimeCond(
     min: DateTime.fromMicrosecondsSinceEpoch(fromTime),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.3.43+253
+version: 0.3.44+254
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description
Issue: Files downloaded to Pictures/Camera folders from Signal app were getting imported in the DB.
As per photo_manager app, the asset pixel width and height was (0.0,0.0) but the library was not returning the asset with default size constraints 
```
const SizeConstraint({
    this.minWidth = 0,
    this.maxWidth = 100000,
    this.minHeight = 0,
    this.maxHeight = 100000,
    this.ignoreSize = false,
  });
```
## Test Plan
- Verified locally that the file downloaded from signal app was imported to ente.