### PR TITLE
Use a multi-subscription stream for Sentry errors

### DIFF
--- a/thirdparty/super_logging/lib/super_logging.dart
+++ b/thirdparty/super_logging/lib/super_logging.dart
@@ -261,7 +261,7 @@ class SuperLogging {
   static late bool sentryIsEnabled;
 
   static Future<void> setupSentry() async {
-    await for (final error in sentryQueueControl.stream) {
+    await for (final error in sentryQueueControl.stream.asBroadcastStream()) {
       try {
         Sentry.captureException(
           error,


### PR DESCRIPTION
## Description
A Dart stream can only have a single listener. Transform it to a broadcast-stream so that there can be multiple.

## Test Plan
