### PR TITLE
Remove support chat

### DIFF
--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -1,10 +1,8 @@
-import 'package:crisp/crisp.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_email_sender/flutter_email_sender.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
-import 'package:photos/ui/loading_widget.dart';
 import 'package:photos/ui/settings/settings_section_title.dart';
 import 'package:photos/ui/settings/settings_text_item.dart';
 import 'package:photos/ui/web_page.dart';
@@ -36,20 +34,6 @@ class SupportSectionWidget extends StatelessWidget {
             }
           },
           child: SettingsTextItem(text: "email", icon: Icons.navigate_next),
-        ),
-        Divider(height: 4),
-        GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () async {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (BuildContext context) {
-                  return CrispChatPage();
-                },
-              ),
-            );
-          },
-          child: SettingsTextItem(text: "chat", icon: Icons.navigate_next),
         ),
         Divider(height: 4),
         GestureDetector(
@@ -91,44 +75,6 @@ class SupportSectionWidget extends StatelessWidget {
               text: "report bug 🐞", icon: Icons.navigate_next),
         ),
       ],
-    );
-  }
-}
-
-class CrispChatPage extends StatefulWidget {
-  CrispChatPage({Key key}) : super(key: key);
-
-  @override
-  _CrispChatPageState createState() => _CrispChatPageState();
-}
-
-class _CrispChatPageState extends State<CrispChatPage> {
-  static const websiteID = "86d56ea2-68a2-43f9-8acb-95e06dee42e8";
-  CrispMain _crisp;
-
-  @override
-  void initState() {
-    _crisp = CrispMain(
-      websiteId: websiteID,
-    );
-    _crisp.register(
-      user: CrispUser(
-        email: Configuration.instance.getUserID().toString() + "@ente.io",
-      ),
-    );
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("support chat"),
-      ),
-      body: CrispView(
-        crispMain: _crisp,
-        loadingWidget: loadWidget,
-      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,8 +28,6 @@ dependencies:
   computer: ^2.0.0
   confetti: ^0.6.0
   connectivity: ^3.0.3
-  crisp:
-    git: "https://github.com/kcrebound/flutter-crisp.git"
   cupertino_icons: ^1.0.0
   device_info: ^2.0.2
   dio: ^4.0.0


### PR DESCRIPTION
## Description
Remove Crisp chat since it comes across as a privacy unfriendly service. Most of our support conversations happen over email anyway.

## Test Plan
- [x] Manually verified that the option has been removed