### PR TITLE
Decouple local and remote syncs

### DIFF
--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -106,7 +106,7 @@ class RemoteSyncService {
   }
 
   Future<void> _pullDiff(bool silently) async {
-    bool isFirstSync = !_collectionsService.hasSyncedCollections();
+    final isFirstSync = !_collectionsService.hasSyncedCollections();
     await _collectionsService.sync();
 
     if (isFirstSync || _hasReSynced()) {

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -88,8 +88,7 @@ class RemoteSyncService {
       _existingSync = null;
       if (hasUploadedFiles) {
         await _pullDiff(true);
-        final pending = await _getFilesToBeUploaded();
-        final hasMoreFilesToBackup = pending.isNotEmpty;
+        final hasMoreFilesToBackup = (await _getFilesToBeUploaded()).isNotEmpty;
         if (hasMoreFilesToBackup && !_shouldThrottleSync()) {
           // Skipping a resync to ensure that files that were ignored in this
           // session are not processed now

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -84,10 +84,10 @@ class RemoteSyncService {
           .onError((e, s) => _logger.severe('trash sync failed', e, s));
       final filesToBeUploaded = await _getFilesToBeUploaded();
       final hasUploadedFiles = await _uploadFiles(filesToBeUploaded);
-      _existingSync.complete();
-      _existingSync = null;
       if (hasUploadedFiles) {
         await _pullDiff(true);
+        _existingSync.complete();
+        _existingSync = null;
         final hasMoreFilesToBackup = (await _getFilesToBeUploaded()).isNotEmpty;
         if (hasMoreFilesToBackup && !_shouldThrottleSync()) {
           // Skipping a resync to ensure that files that were ignored in this
@@ -96,6 +96,9 @@ class RemoteSyncService {
         } else {
           Bus.instance.fire(SyncStatusUpdate(SyncStatus.completed_backup));
         }
+      } else {
+        _existingSync.complete();
+        _existingSync = null;
       }
     } catch (e, s) {
       _logger.severe("Error executing remote sync ", e, s);

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -52,6 +52,14 @@ class RemoteSyncService {
 
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
+
+    Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) async {
+      if (event.type == EventType.addedOrUpdated) {
+        if (_existingSync == null) {
+          sync();
+        }
+      }
+    });
   }
 
   Future<void> sync({bool silently = false}) async {
@@ -65,20 +73,8 @@ class RemoteSyncService {
     }
     _existingSync = Completer<void>();
 
-    bool isFirstSync = !_collectionsService.hasSyncedCollections();
-
     try {
-      await _collectionsService.sync();
-
-      if (isFirstSync || _hasReSynced()) {
-        await _syncUpdatedCollections(silently);
-      } else {
-        final syncSinceTime = _getSinceTimeForReSync();
-        await _resyncAllCollectionsSinceTime(syncSinceTime);
-      }
-      if (!_hasReSynced()) {
-        await _markReSyncAsDone();
-      }
+      await _pullDiff(silently);
       // sync trash but consume error during initial launch.
       // this is to ensure that we don't pause upload due to any error during
       // the trash sync. Impact: We may end up re-uploading a file which was
@@ -86,18 +82,41 @@ class RemoteSyncService {
       await TrashSyncService.instance
           .syncTrash()
           .onError((e, s) => _logger.severe('trash sync failed', e, s));
-      bool hasUploadedFiles = await _uploadDiff();
+      final filesToBeUploaded = await _getFilesToBeUploaded();
+      final hasUploadedFiles = await _uploadFiles(filesToBeUploaded);
       _existingSync.complete();
       _existingSync = null;
-      if (hasUploadedFiles && !_shouldThrottleSync()) {
-        // Skipping a resync to ensure that files that were ignored in this
-        // session are not processed now
-        sync(silently: true);
+      if (hasUploadedFiles) {
+        await _pullDiff(true);
+        final pending = await _getFilesToBeUploaded();
+        final hasMoreFilesToBackup = pending.isNotEmpty;
+        if (hasMoreFilesToBackup && !_shouldThrottleSync()) {
+          // Skipping a resync to ensure that files that were ignored in this
+          // session are not processed now
+          sync();
+        } else {
+          Bus.instance.fire(SyncStatusUpdate(SyncStatus.completed_backup));
+        }
       }
     } catch (e, s) {
       _logger.severe("Error executing remote sync ", e, s);
       _existingSync.complete();
       _existingSync = null;
+    }
+  }
+
+  Future<void> _pullDiff(bool silently) async {
+    bool isFirstSync = !_collectionsService.hasSyncedCollections();
+    await _collectionsService.sync();
+
+    if (isFirstSync || _hasReSynced()) {
+      await _syncUpdatedCollections(silently);
+    } else {
+      final syncSinceTime = _getSinceTimeForReSync();
+      await _resyncAllCollectionsSinceTime(syncSinceTime);
+    }
+    if (!_hasReSynced()) {
+      await _markReSyncAsDone();
     }
   }
 
@@ -159,7 +178,7 @@ class RemoteSyncService {
     }
   }
 
-  Future<bool> _uploadDiff() async {
+  Future<List<File>> _getFilesToBeUploaded() async {
     final foldersToBackUp = Configuration.instance.getPathsToBackUp();
     List<File> filesToBeUploaded;
     if (LocalSyncService.instance.hasGrantedLimitedPermissions() &&
@@ -186,7 +205,10 @@ class RemoteSyncService {
     _moveVideosToEnd(filesToBeUploaded);
     _logger.info(
         filesToBeUploaded.length.toString() + " new files to be uploaded.");
+    return filesToBeUploaded;
+  }
 
+  Future<bool> _uploadFiles(List<File> filesToBeUploaded) async {
     final updatedFileIDs = await _db.getUploadedFileIDsToBeUpdated();
     _logger.info(updatedFileIDs.length.toString() + " files updated.");
 

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -65,9 +65,6 @@ class SyncService {
       await PhotoManager.clearFileCache();
       _logger.info("Cleared file cache");
     }
-    if (LocalSyncService.instance.hasGrantedPermissions()) {
-      LocalSyncService.instance.addChangeCallback(() => sync());
-    }
   }
 
   Future<bool> existingSync() async {
@@ -155,7 +152,6 @@ class SyncService {
     await _localSyncService.onPermissionGranted(state);
     Bus.instance.fire(PermissionGrantedEvent());
     _doSync();
-    LocalSyncService.instance.addChangeCallback(() => sync());
   }
 
   void onFoldersSet(Set<String> paths) {


### PR DESCRIPTION
## Description
- Maintain separate state for `LocalSyncService`, so that whenever a change is observed on disk, it's applied to the local DB immediately
- Post every sync within `RemoteSyncService`, query if there are files left to be uploaded, if yes, trigger a re-sync

> Note: A better approach would have been to push the newly discovered files to the existing upload queue. But that is a more disruptive change. This diff is an improvement over the current scheme of things, and we will only have to refactor `RemoteSyncService` in the future to achieve the desired result.

## Test Plan
- [x] Manually tested by taking multiple screenshots while the app is in foreground
