### PR TITLE
Throttle log statements to prevent crash

### DIFF
--- a/lib/services/deduplication_service.dart
+++ b/lib/services/deduplication_service.dart
@@ -34,6 +34,7 @@ class DeduplicationService {
   List<DuplicateFiles> _filterDuplicatesByCreationTime(
       DuplicateFilesResponse dupes, Map<int, File> fileMap) {
     final result = <DuplicateFiles>[];
+    final missingFileIDs = <int>[];
     for (final dupe in dupes.duplicates) {
       final files = <File>[];
       final Map<int, int> creationTimeCounter = {};
@@ -55,10 +56,7 @@ class DeduplicationService {
           }
           files.add(file);
         } else {
-          _logger.severe(
-              "Missing file",
-              InvalidStateError(
-                  "Could not find file in local DB " + id.toString()));
+          missingFileIDs.add(id);
         }
       }
       // Ignores those files that were not created within the most common creationTime
@@ -82,6 +80,14 @@ class DeduplicationService {
       if (files.length > 1) {
         result.add(DuplicateFiles(files, dupe.size));
       }
+    }
+    if (missingFileIDs.isNotEmpty) {
+      _logger.severe(
+          "Missing files",
+          InvalidStateError("Could not find " +
+              missingFileIDs.length.toString() +
+              " files in local DB: " +
+              missingFileIDs.toString()));
     }
     return result;
   }


### PR DESCRIPTION
## Description
A flurry of log statements to disk was causing the app to crash on iOS. This change collects such errors encountered during deduplication and prints them in a single line.

Fixes https://github.com/ente-io/frame/issues/159.

## Test Plan
- [x] Reproduced the crash and manually verified that this change fixes it.