### PR TITLE
handle error while displaying sharingDialog

### DIFF
--- a/lib/ui/gallery_app_bar_widget.dart
+++ b/lib/ui/gallery_app_bar_widget.dart
@@ -214,36 +214,34 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     var collection = widget.collection;
     final dialog = createProgressDialog(context, "please wait...");
     await dialog.show();
-    if (collection == null) {
-      if (widget.type == GalleryAppBarType.local_folder) {
-        collection =
-            CollectionsService.instance.getCollectionForPath(widget.path);
-        if (collection == null) {
-          try {
-            collection = await CollectionsService.instance
-                .getOrCreateForPath(widget.path);
-          } catch (e, s) {
-            _logger.severe(e, s);
-            await dialog.hide();
-            showGenericErrorDialog(context);
-          }
+    try {
+      if (collection == null) {
+        if (widget.type == GalleryAppBarType.local_folder) {
+          collection =
+              CollectionsService.instance.getCollectionForPath(widget.path);
+          collection ??=
+              await CollectionsService.instance.getOrCreateForPath(widget.path);
+        } else {
+          throw Exception(
+              "Cannot create a collection of type" + widget.type.toString());
         }
       } else {
-        throw Exception(
-            "Cannot create a collection of type" + widget.type.toString());
+        final sharees =
+            await CollectionsService.instance.getSharees(collection.id);
+        collection = collection.copyWith(sharees: sharees);
       }
-    } else {
-      final sharees =
-          await CollectionsService.instance.getSharees(collection.id);
-      collection = collection.copyWith(sharees: sharees);
+      await dialog.hide();
+      return showDialog<void>(
+        context: context,
+        builder: (BuildContext context) {
+          return SharingDialog(collection);
+        },
+      );
+    } catch (e, s) {
+      _logger.severe(e, s);
+      await dialog.hide();
+      showGenericErrorDialog(context);
     }
-    await dialog.hide();
-    return showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        return SharingDialog(collection);
-      },
-    );
   }
 
   Future<void> _createAlbum() async {

--- a/lib/ui/gallery_app_bar_widget.dart
+++ b/lib/ui/gallery_app_bar_widget.dart
@@ -218,8 +218,6 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
       if (collection == null) {
         if (widget.type == GalleryAppBarType.local_folder) {
           collection =
-              CollectionsService.instance.getCollectionForPath(widget.path);
-          collection ??=
               await CollectionsService.instance.getOrCreateForPath(widget.path);
         } else {
           throw Exception(


### PR DESCRIPTION
## Description
Bug: In case of no internet, the progress dialog was never dismissed.

## Test Plan
Verified that the progress dialog was dismissed when there was no network.
