### PR TITLE
Bugfix: Logout user on invalid token

### DIFF
--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -104,6 +104,9 @@ class RemoteSyncService {
       _logger.severe("Error executing remote sync ", e, s);
       _existingSync.complete();
       _existingSync = null;
+      if (e is UnauthorizedError) {
+        rethrow;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Bug: App didn't log me when the token wasn't valid.

## Test Plan
- Saw the `session expiry` dialog after adding this fix.
