### PR TITLE
Fix: Handle repeated upload for file with new localID

### DIFF
--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -338,9 +338,17 @@ class RemoteSyncService {
         // File exists in ente db with same title & device folder
         // Note: The file.generatedID might be already set inside
         // [DiffFetcher.getEncryptedFilesDiff]
-
-        final fileWithLocalID = existingFiles
-            .firstWhere((e) => e.localID != null, orElse: () => null);
+        // Try to find existing file with same localID as remote file with a fallback
+        // to finding any existing file with localID. This is needed to handle
+        // case when localID for a file changes and the file is uploaded again in
+        // the same collection
+        final fileWithLocalID = existingFiles.firstWhere(
+            (e) =>
+                file.localID != null &&
+                e.localID != null &&
+                e.localID == file.localID,
+            orElse: () => existingFiles.firstWhere((e) => e.localID != null,
+                orElse: () => null));
         if (fileWithLocalID != null) {
           // File should ideally have the same localID
           if (file.localID != null && file.localID != fileWithLocalID.localID) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.4.13+273
+version: 0.4.14+274
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description
Bug: 
- File with local ID1 is imported and uploaded to ente.
- The local ID for the file changes from `ID1` -> ID2`. 
- The same file is uploaded again with the same name & device folder. 
- While processing the remote response for the file with `ID2`, we were overwriting the local ID to `ID1`.
- During the next scan for local files, the file with `ID2` is picked up again for upload.

Fix:
- Give preference to the same local ID as the remote file with a fallback to any non-null localID (existing logic).
## Test Plan
