### PR TITLE
trim email id

### DIFF
--- a/lib/ui/login_page.dart
+++ b/lib/ui/login_page.dart
@@ -68,7 +68,7 @@ class _LoginPageState extends State<LoginPage> {
             ),
             onChanged: (value) {
               setState(() {
-                _email = value;
+                _email = value.trim();
               });
             },
             autocorrect: false,


### PR DESCRIPTION
## Description
Issue: The email auto-fill service adds a space after auto-filling. Pressing next results in an invalid email error.

## Test Plan
