### PR TITLE
Switch to compileSdkVersion 31

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.20'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Description
Build fails with newer pkgs because they refer to attributes present in the newer version of Android.
## Test Plan
- Verified that the android build succeeds without any error.