### PR TITLE
Wrap tab bar in safe area

### DIFF
--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -293,19 +293,11 @@ class _HomeWidgetState extends State<HomeWidget> {
         Align(alignment: Alignment.bottomCenter, child: BottomShadowWidget()),
         Align(
           alignment: Alignment.bottomCenter,
-          child: Stack(
-            children: [
-              Column(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  HomeBottomNavigationBar(
-                    _selectedFiles,
-                    selectedTabIndex: _selectedTabIndex,
-                  ),
-                  const SizedBox(height: 8),
-                ],
-              ),
-            ],
+          child: SafeArea(
+            child: HomeBottomNavigationBar(
+              _selectedFiles,
+              selectedTabIndex: _selectedTabIndex,
+            ),
           ),
         ),
         Align(


### PR DESCRIPTION
Earlier, the tab bar at the bottom of the main screen was wrapped in a SafeArea widget so that it does not overlap the bottom hard to tap regions on iPhones. Looks like that during the code changes for the redesign, this SafeArea was lost.

Introduce the SafeArea back. Additionally, from a very quick glance it seems that the stack and additional padding that had replaced the safe area were not necessarily needed, so I've simplified the widget structure. But this is a very quick and dirty example, I've only tested that it looks visually okay on iPhone 13. Maybe there were functional reasons for the old widgets, or maybe those were needed on Android, so please consider this PR only as a starting point.

How it looks after the change:

![IMG_288099C1610A-1](https://user-images.githubusercontent.com/24503581/167476578-e415e892-4f0b-49d4-85e6-70bd2c5d78d7.jpeg)

