### PR TITLE
Delete confirmation

### DIFF
--- a/lib/ui/common/dialogs.dart
+++ b/lib/ui/common/dialogs.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 enum DialogUserChoice { firstChoice, secondChoice }
@@ -8,7 +7,7 @@ enum ActionType {
   critical,
 }
 // if dialog is dismissed by tapping outside, this will return null
-Future<T> showChoiceDialog<T>(
+Future<DialogUserChoice> showChoiceDialog<T>(
   BuildContext context,
   String title,
   String content, {


### PR DESCRIPTION
## Description
- Force confirmation in case local-only files are being deleted on Android since they are hard to recover

## Test Plan
- [x] Tested locally to ensure that the confirmation dialog is shown

![2022-05-12 17 53 41](https://user-images.githubusercontent.com/1161789/168073900-40cc7ac7-7d16-4da5-9f1c-b42b2c6eb303.jpg)

