### PR TITLE
Add tunnel for Sentry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,8 @@
 [submodule "thirdparty/plugins"]
 	path = thirdparty/plugins
 	url = https://github.com/ente-io/plugins.git
+
+[submodule "thirdparty/sentry-dart"]
+	path = thirdparty/sentry-dart
+	url = https://github.com/ente-io/sentry-dart.git
+

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -7,6 +7,7 @@ const String kSentryDSN =
     "https://2235e5c99219488ea93da34b9ac1cb68@sentry.ente.io/4";
 const String kSentryDebugDSN =
     "https://ca5e686dd7f149d9bf94e620564cceba@sentry.ente.io/3";
+const String kSentryTunnel = "https://sentry-reporter.ente.io";
 const String kRoadmapURL = "https://roadmap.ente.io";
 const int kMicroSecondsInDay = 86400000000;
 const int kAndroid11SDKINT = 30;

--- a/lib/core/error-reporting/tunneled_transport.dart
+++ b/lib/core/error-reporting/tunneled_transport.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'package:http/http.dart';
+import 'package:sentry/sentry.dart';
+
+/// A transport is in charge of sending the event to the Sentry server.
+class TunneledTransport implements Transport {
+  final Uri _tunnel;
+  final SentryOptions _options;
+
+  final Dsn _dsn;
+
+  _CredentialBuilder _credentialBuilder;
+
+  final Map<String, String> _headers;
+
+  factory TunneledTransport(Uri tunnel, SentryOptions options) {
+    return TunneledTransport._(tunnel, options);
+  }
+
+  TunneledTransport._(this._tunnel, this._options)
+      : _dsn = Dsn.parse(_options.dsn),
+        _headers = _buildHeaders(
+          _options.platformChecker.isWeb,
+          _options.sdk.identifier,
+        ) {
+    _credentialBuilder = _CredentialBuilder(
+      _dsn,
+      _options.sdk.identifier,
+      _options.clock,
+    );
+  }
+
+  @override
+  Future<SentryId> send(SentryEnvelope envelope) async {
+    final streamedRequest = await _createStreamedRequest(envelope);
+    final response = await _options.httpClient
+        .send(streamedRequest)
+        .then(Response.fromStream);
+
+    if (response.statusCode != 200) {
+      // body guard to not log the error as it has performance impact to allocate
+      // the body String.
+      if (_options.debug) {
+        _options.logger(
+          SentryLevel.error,
+          'API returned an error, statusCode = ${response.statusCode}, '
+          'body = ${response.body}',
+        );
+      }
+      return SentryId.empty();
+    } else {
+      _options.logger(
+        SentryLevel.debug,
+        'Envelope ${envelope.header.eventId ?? "--"} was sent successfully.',
+      );
+    }
+
+    final eventId = json.decode(response.body)['id'];
+    if (eventId == null) {
+      return null;
+    }
+    return SentryId.fromId(eventId);
+  }
+
+  Future<StreamedRequest> _createStreamedRequest(
+      SentryEnvelope envelope) async {
+    final streamedRequest = StreamedRequest('POST', _tunnel);
+    envelope
+        .envelopeStream(_options)
+        .listen(streamedRequest.sink.add)
+        .onDone(streamedRequest.sink.close);
+
+    streamedRequest.headers.addAll(_credentialBuilder.configure(_headers));
+
+    return streamedRequest;
+  }
+}
+
+class _CredentialBuilder {
+  final String _authHeader;
+
+  final ClockProvider _clock;
+
+  int get timestamp => _clock().millisecondsSinceEpoch;
+
+  _CredentialBuilder._(String authHeader, ClockProvider clock)
+      : _authHeader = authHeader,
+        _clock = clock;
+
+  factory _CredentialBuilder(
+      Dsn dsn, String sdkIdentifier, ClockProvider clock) {
+    final authHeader = _buildAuthHeader(
+      publicKey: dsn.publicKey,
+      secretKey: dsn.secretKey,
+      sdkIdentifier: sdkIdentifier,
+    );
+
+    return _CredentialBuilder._(authHeader, clock);
+  }
+
+  static String _buildAuthHeader({
+    String publicKey,
+    String secretKey,
+    String sdkIdentifier,
+  }) {
+    var header = 'Sentry sentry_version=7, sentry_client=$sdkIdentifier, '
+        'sentry_key=$publicKey';
+
+    if (secretKey != null) {
+      header += ', sentry_secret=$secretKey';
+    }
+
+    return header;
+  }
+
+  Map<String, String> configure(Map<String, String> headers) {
+    return headers
+      ..addAll(
+        <String, String>{
+          'X-Sentry-Auth': '$_authHeader, sentry_timestamp=$timestamp'
+        },
+      );
+  }
+}
+
+Map<String, String> _buildHeaders(bool isWeb, String sdkIdentifier) {
+  final headers = {'Content-Type': 'application/x-sentry-envelope'};
+  // NOTE(lejard_h) overriding user agent on VM and Flutter not sure why
+  // for web it use browser user agent
+  if (!isWeb) {
+    headers['User-Agent'] = sdkIdentifier;
+  }
+  return headers;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -159,6 +159,7 @@ Future _runWithLogs(Function() function, {String prefix = ""}) async {
     logDirPath: (await getTemporaryDirectory()).path + "/logs",
     maxLogFiles: 5,
     sentryDsn: kDebugMode ? kSentryDebugDSN : kSentryDSN,
+    tunnel: kSentryTunnel,
     enableInDebugMode: true,
     prefix: prefix,
   ));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1003,16 +1003,16 @@ packages:
   sentry:
     dependency: "direct main"
     description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "thirdparty/sentry-dart/dart"
+      relative: true
+    source: path
     version: "6.5.1"
   sentry_flutter:
     dependency: "direct main"
     description:
-      name: sentry_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "thirdparty/sentry-dart/flutter"
+      relative: true
+    source: path
     version: "6.5.1"
   share:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,8 +89,10 @@ dependencies:
   quiver: ^3.0.1
   receive_sharing_intent: ^1.4.5
   scrollable_positioned_list: ^0.2.2
-  sentry: ^6.5.1
-  sentry_flutter: ^6.5.1
+  sentry:
+    path: thirdparty/sentry-dart/dart
+  sentry_flutter:
+    path: thirdparty/sentry-dart/flutter
   share_plus: ^4.0.4
   shared_preferences: ^2.0.5
   sqflite: ^2.0.0+3


### PR DESCRIPTION
## Description
Tunneling Sentry reports enables us to attach secrets to the requests (as is required by Cloudflare Access).

## Test Plan
- [x] Verified that the tunneled errors are reported as expected
