### PR TITLE
Fix bug trash diff sync

### DIFF
--- a/lib/utils/trash_diff_fetcher.dart
+++ b/lib/utils/trash_diff_fetcher.dart
@@ -33,15 +33,17 @@ class TrashDiffFetcher {
         final diff = response.data["diff"] as List;
         final bool hasMore = response.data["hasMore"] as bool;
         final startTime = DateTime.now();
+        final trash = TrashFile();
+
         for (final item in diff) {
+          trash.createdAt = item['createdAt'];
+          trash.updateAt = item['updatedAt'];
+          latestUpdatedAtTime = max(latestUpdatedAtTime, trash.updateAt);
           if (item["isDeleted"]) {
             deletedUploadIDs.add(item["file"]["id"]);
             continue;
           }
-          final trash = TrashFile();
-          trash.createdAt = item['createdAt'];
-          trash.updateAt = item['updatedAt'];
-          latestUpdatedAtTime = max(latestUpdatedAtTime, trash.updateAt);
+
           trash.deleteBy = item['deleteBy'];
           trash.uploadedFileID = item["file"]["id"];
           trash.collectionID = item["file"]["collectionID"];

--- a/lib/utils/trash_diff_fetcher.dart
+++ b/lib/utils/trash_diff_fetcher.dart
@@ -33,9 +33,8 @@ class TrashDiffFetcher {
         final diff = response.data["diff"] as List;
         final bool hasMore = response.data["hasMore"] as bool;
         final startTime = DateTime.now();
-        final trash = TrashFile();
-
         for (final item in diff) {
+          final trash = TrashFile();
           trash.createdAt = item['createdAt'];
           trash.updateAt = item['updatedAt'];
           latestUpdatedAtTime = max(latestUpdatedAtTime, trash.updateAt);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.5.25+305
+version: 0.5.26+306
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description
When all files are deleted in a sync response, then trash's latestUpdatedAtTime (aka synced time) was not getting updated correctly.
## Test Plan
