### PR TITLE
Support Email: Fix invalid email issue for proton mail client

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -28,3 +28,5 @@ const kMnemonicKeyWordCount = 24;
 
 // https://stackoverflow.com/a/61162219
 const kDragSensitivity = 8;
+
+const kSupportEmail = 'support@ente.io';

--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_email_sender/flutter_email_sender.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/ui/settings/settings_section_title.dart';
 import 'package:photos/ui/settings/settings_text_item.dart';
 import 'package:photos/ui/web_page.dart';
+import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/email_util.dart';
-import 'package:photos/utils/toast_util.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SupportSectionWidget extends StatelessWidget {
@@ -23,14 +22,14 @@ class SupportSectionWidget extends StatelessWidget {
           behavior: HitTestBehavior.translucent,
           onTap: () async {
             try {
-              final Email email = Email(
-                recipients: ['hey@ente.io'],
-                isHTML: false,
+              final Uri emailLaunchUri = Uri(
+                scheme: 'mailto',
+                path: kSupportEmail,
               );
-              await FlutterEmailSender.send(email);
+              launchUrl(emailLaunchUri);
             } catch (e) {
               Logger("SupportSection").severe(e);
-              launch("mailto:hey@ente.io");
+              showErrorDialog(context, "", "please email us at $kSupportEmail");
             }
           },
           child: SettingsTextItem(text: "email", icon: Icons.navigate_next),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       name: flutter_email_sender
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.0"
   flutter_image_compress:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   flutter_cache_manager: ^3.3.0
   flutter_datetime_picker: ^1.5.1
   flutter_easyloading: ^3.0.0
-  flutter_email_sender: 5.0.2
+  flutter_email_sender: ^5.1.0
   flutter_image_compress: ^1.1.0
   flutter_inappwebview: ^5.3.2
   flutter_local_notifications: ^9.5.3+1


### PR DESCRIPTION
## Description
While using flutter_email_sender and selecting ProtonMail (on Android) as client doesn't auto-fill the email id field. 
ProtonMail client throws the following error:  `The email address " is invalid and was removed.`

```lang=dart
final Email email = Email(recipients: ["support@example.com"]);
await FlutterEmailSender.send(email);
```
![2022-05-31 13 35 13](https://user-images.githubusercontent.com/254676/171124099-d761ff5e-d272-4efd-9a3f-f385880497b0.jpg)

Pending: Need to fix the issue for report bug flow as well.


## Test Plan
- Verified that email field is auto filled when Proton Mail client was selected.