### PR TITLE
Fix location attributes while converting Asset to File

### DIFF
--- a/lib/models/file.dart
+++ b/lib/models/file.dart
@@ -65,7 +65,8 @@ class File {
     file.localID = asset.id;
     file.title = asset.title;
     file.deviceFolder = pathName;
-    file.location = Location(asset.latitude, asset.longitude);
+    var latLng = await asset.latlngAsync();
+    file.location = Location(latLng.longitude, latLng.latitude);
     file.fileType = _fileTypeFromAsset(asset);
     file.creationTime = asset.createDateTime.microsecondsSinceEpoch;
     if (file.creationTime == 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.5.34+314
+version: 0.5.35+315
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description
As per photos manager documentation:
```dart
/// Latitude value of the location when shooting.
  ///  * Android: `MediaStore.Images.ImageColumns.LONGITUDE`.
  ///  * iOS/macOS: `PHAsset.location.coordinate.longitude`.
  ///
  /// It's always null when the device is Android 10 or above.
  ///
  /// See also:
  ///  * https://developer.android.com/reference/android/provider/MediaStore.Images.ImageColumns#LATITUDE
  ///  * https://developer.apple.com/documentation/corelocation/cllocation?language=objc#declaration
  double? get longitude => _longitude;
```

```dart
/// Obtain latitude and longitude.
  ///  * Android: Obtain from `MediaStore` or EXIF (Android 10).
  ///  * iOS/macOS: Obtain from photos.
  ///
  /// [LatLng.latitude] and [LatLng.longitude] might be 0.
  Future<LatLng> latlngAsync() => plugin.getLatLngAsync(this);
```
## Test Plan
