### PR TITLE
Gracefully handle failure in freespace api call

### DIFF
--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -104,7 +104,15 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
           onTap: () async {
             final dialog = createProgressDialog(context, "calculating...");
             await dialog.show();
-            final status = await SyncService.instance.getBackupStatus();
+            BackupStatus status;
+            try {
+              status = await SyncService.instance.getBackupStatus();
+            } catch (e, s) {
+              await dialog.hide();
+              showGenericErrorDialog(context);
+              return;
+            }
+
             await dialog.hide();
             if (status.localIDs.isEmpty) {
               showErrorDialog(context, "✨ all clear",


### PR DESCRIPTION
## Description
Issue: In case of failure in `getBackupStatus` call, the dialog wasn't getting dismissed.
## Test Plan
Tested locally.
