### PR TITLE
Tweak the separators on the settings screen

### DIFF
--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -52,7 +52,7 @@ class SettingsPage extends StatelessWidget {
     );
     final sectionDivider = Divider(
       height: 20,
-      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.4),
+      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
     );
     contents.add(Padding(padding: EdgeInsets.all(4)));
     if (hasLoggedIn) {


### PR DESCRIPTION
They were overwhelming before, toned them down to match the new separator color from the palette we'll be using. 

Verified the look on both light/dark.

Before:

![IMG_C8F1766578C3-1](https://user-images.githubusercontent.com/24503581/173170761-96920796-6518-4953-8153-961649589b2f.jpeg)


After:

![IMG_1281](https://user-images.githubusercontent.com/24503581/173170739-46e16038-31f7-4e5e-88af-18f877090d54.PNG)

