### PR TITLE
Fix: Sync all files on disk change when limited permission is granted

### DIFF
--- a/lib/services/local_sync_service.dart
+++ b/lib/services/local_sync_service.dart
@@ -275,12 +275,18 @@ class LocalSyncService {
   }
 
   void _registerChangeCallback() {
+    // In case of iOS limit permission, this call back is fired immediately
+    // after file selection dialog is dismissed.
     PhotoManager.addChangeCallback((value) async {
       _logger.info("Something changed on disk");
       if (_existingSync != null) {
         await _existingSync.future;
       }
-      sync();
+      if (hasGrantedLimitedPermissions()) {
+        syncAll();
+      } else {
+        sync();
+      }
     });
     PhotoManager.startChangeNotify();
   }


### PR DESCRIPTION
## Description
Sync does a differential sync where it fetches newer files from previous sync.
SyncAll will fetch all files which can be accessed by the app and import them in local DB if they are not already imported.

## Test Plan
Tested on simulator and verified the fix.
