### PR TITLE
Hide hidden memories from memories widget 🍭 

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -580,10 +580,10 @@ class FilesDB {
 
   Future<List<File>> getFilesCreatedWithinDurations(
     List<List<int>> durations,
-      Set<int> ignoredCollectionIDs,
+    Set<int> ignoredCollectionIDs,
   ) async {
     final db = await instance.database;
-    String whereClause = "";
+    String whereClause = "( ";
     for (int index = 0; index < durations.length; index++) {
       whereClause += "($columnCreationTime > " +
           durations[index][0].toString() +
@@ -594,13 +594,14 @@ class FilesDB {
         whereClause += " OR ";
       }
     }
+    whereClause += ") AND $columnMMdVisibility = $kVisibilityVisible";
     final results = await db.query(
       table,
       where: whereClause,
       orderBy: '$columnCreationTime ASC',
     );
     final files = _convertToFiles(results);
-    return _deduplicatedAndFilterIgnoredFiles(files, ignoredCollectionIDs)
+    return _deduplicatedAndFilterIgnoredFiles(files, ignoredCollectionIDs);
   }
 
   Future<List<File>> getFilesToBeUploadedWithinFolders(

--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -580,6 +580,7 @@ class FilesDB {
 
   Future<List<File>> getFilesCreatedWithinDurations(
     List<List<int>> durations,
+      Set<int> ignoredCollectionIDs,
   ) async {
     final db = await instance.database;
     String whereClause = "";
@@ -598,7 +599,8 @@ class FilesDB {
       where: whereClause,
       orderBy: '$columnCreationTime ASC',
     );
-    return _convertToFiles(results);
+    final files = _convertToFiles(results);
+    return _deduplicatedAndFilterIgnoredFiles(files, ignoredCollectionIDs)
   }
 
   Future<List<File>> getFilesToBeUploadedWithinFolders(

--- a/lib/models/filters/important_items_filter.dart
+++ b/lib/models/filters/important_items_filter.dart
@@ -10,25 +10,17 @@ class ImportantItemsFilter implements GalleryItemsFilter {
 
   @override
   bool shouldInclude(File file) {
-    if (_importantPaths.isEmpty) {
-      if (Platform.isAndroid) {
-        if (file.uploadedFileID != null) {
-          return true;
-        }
-        final String folder = basename(file.deviceFolder);
-        return folder == "Camera" ||
-            folder == "Recents" ||
-            folder == "DCIM" ||
-            folder == "Download" ||
-            folder == "Screenshot";
-      } else {
-        return true;
-      }
-    }
     if (file.uploadedFileID != null) {
       return true;
     }
-    final folder = basename(file.deviceFolder);
+    final String folder = basename(file.deviceFolder);
+    if (_importantPaths.isEmpty && Platform.isAndroid) {
+      return folder == "Camera" ||
+          folder == "Recents" ||
+          folder == "DCIM" ||
+          folder == "Download" ||
+          folder == "Screenshot";
+    }
     return _importantPaths.contains(folder);
   }
 }

--- a/lib/services/memories_service.dart
+++ b/lib/services/memories_service.dart
@@ -5,6 +5,7 @@ import 'package:photos/db/files_db.dart';
 import 'package:photos/db/memories_db.dart';
 import 'package:photos/models/filters/important_items_filter.dart';
 import 'package:photos/models/memory.dart';
+import 'package:photos/services/collections_service.dart';
 
 class MemoriesService extends ChangeNotifier {
   final _logger = Logger("MemoryService");
@@ -70,7 +71,10 @@ class MemoriesService extends ChangeNotifier {
           date.add(Duration(days: daysAfter)).microsecondsSinceEpoch;
       durations.add([startCreationTime, endCreationTime]);
     }
-    final files = await _filesDB.getFilesCreatedWithinDurations(durations);
+    final archivedCollectionIds =
+        CollectionsService.instance.getArchivedCollections();
+    final files = await _filesDB.getFilesCreatedWithinDurations(
+        durations, archivedCollectionIds);
     final seenTimes = await _memoriesDB.getSeenTimes();
     final List<Memory> memories = [];
     final filter = ImportantItemsFilter();

--- a/lib/ui/memories_widget.dart
+++ b/lib/ui/memories_widget.dart
@@ -334,8 +334,8 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
       child: IconButton(
         icon: Icon(
           Icons.adaptive.share,
-          color: Colors.white,
-        ), //same for both themes
+          color: Colors.white, //same for both themes
+        ),
         onPressed: () {
           share(context, [file]);
         },


### PR DESCRIPTION
## Description

## Test Plan
- Edited a file time to current date, year 2012 (we only show memories in last 30 years)
- Saw the photo in memories widget after Hot Restart.
- Marked the photo as hidden and verified that it was gone from memory after hot restart.
- Saw the memory again after Unhide + Hot restart.
- Marked the entire collection as hidden and verified that the memory was not visible.
