### PR TITLE
Minor fixes

### DIFF
--- a/lib/ui/settings/account_section_widget.dart
+++ b/lib/ui/settings/account_section_widget.dart
@@ -70,7 +70,7 @@ class AccountSectionWidgetState extends State<AccountSectionWidget> {
           child:
               SettingsTextItem(text: "Recovery key", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {
@@ -95,7 +95,7 @@ class AccountSectionWidgetState extends State<AccountSectionWidget> {
           child:
               SettingsTextItem(text: "Change email", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -55,7 +55,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
           icon: Icons.navigate_next,
         ),
       ),
-      SectionOptionDivider,
+      sectionOptionDivider,
       SizedBox(
         height: 48,
         child: Row(
@@ -75,7 +75,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
           ],
         ),
       ),
-      SectionOptionDivider,
+      sectionOptionDivider,
       SizedBox(
         height: 48,
         child: Row(
@@ -98,7 +98,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
     ];
     if (Platform.isIOS) {
       sectionOptions.addAll([
-        SectionOptionDivider,
+        sectionOptionDivider,
         SizedBox(
           height: 48,
           child: Row(
@@ -134,7 +134,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
     }
     sectionOptions.addAll(
       [
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {
@@ -168,7 +168,7 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
             icon: Icons.navigate_next,
           ),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {

--- a/lib/ui/settings/common_settings.dart
+++ b/lib/ui/settings/common_settings.dart
@@ -4,7 +4,7 @@ import 'package:expandable/expandable.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-Widget SectionOptionDivider = Padding(
+Widget sectionOptionDivider = Padding(
   padding: EdgeInsets.all(Platform.isIOS ? 4 : 2),
 );
 

--- a/lib/ui/settings/danger_section_widget.dart
+++ b/lib/ui/settings/danger_section_widget.dart
@@ -35,7 +35,7 @@ class _DangerSectionWidgetState extends State<DangerSectionWidget> {
           },
           child: SettingsTextItem(text: "Logout", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () {

--- a/lib/ui/settings/info_section_widget.dart
+++ b/lib/ui/settings/info_section_widget.dart
@@ -71,7 +71,7 @@ class InfoSectionWidget extends StatelessWidget {
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {
-            launch("https://github.com/ente-io/frame");
+            launchUrl(Uri.parse("https://github.com/ente-io/frame"));
           },
           child:
               SettingsTextItem(text: "Source code", icon: Icons.navigate_next),

--- a/lib/ui/settings/info_section_widget.dart
+++ b/lib/ui/settings/info_section_widget.dart
@@ -39,7 +39,7 @@ class InfoSectionWidget extends StatelessWidget {
           },
           child: SettingsTextItem(text: "FAQ", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () {
@@ -53,7 +53,7 @@ class InfoSectionWidget extends StatelessWidget {
           },
           child: SettingsTextItem(text: "Terms", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () {
@@ -67,7 +67,7 @@ class InfoSectionWidget extends StatelessWidget {
           },
           child: SettingsTextItem(text: "Privacy", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {
@@ -76,6 +76,7 @@ class InfoSectionWidget extends StatelessWidget {
           child:
               SettingsTextItem(text: "Source code", icon: Icons.navigate_next),
         ),
+        sectionOptionDivider,
         UpdateService.instance.isIndependent()
             ? Column(
                 children: [
@@ -109,7 +110,7 @@ class InfoSectionWidget extends StatelessWidget {
                   ),
                 ],
               )
-            : Container(),
+            : const SizedBox.shrink(),
       ],
     );
   }

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -116,7 +116,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
       );
     }
     children.addAll([
-      SectionOptionDivider,
+      sectionOptionDivider,
       SizedBox(
         height: 48,
         child: Row(
@@ -150,7 +150,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
     if (Platform.isAndroid) {
       children.addAll(
         [
-          SectionOptionDivider,
+          sectionOptionDivider,
           SizedBox(
             height: 48,
             child: Row(
@@ -246,7 +246,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
       );
     }
     children.addAll([
-      SectionOptionDivider,
+      sectionOptionDivider,
       GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: () async {

--- a/lib/ui/settings/social_section_widget.dart
+++ b/lib/ui/settings/social_section_widget.dart
@@ -30,7 +30,7 @@ class SocialSectionWidget extends StatelessWidget {
         },
         child: SettingsTextItem(text: "Twitter", icon: Icons.navigate_next),
       ),
-      SectionOptionDivider,
+      sectionOptionDivider,
       GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: () {
@@ -38,7 +38,7 @@ class SocialSectionWidget extends StatelessWidget {
         },
         child: SettingsTextItem(text: "Discord", icon: Icons.navigate_next),
       ),
-      SectionOptionDivider,
+      sectionOptionDivider,
       GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: () {
@@ -50,7 +50,7 @@ class SocialSectionWidget extends StatelessWidget {
     if (!UpdateService.instance.isIndependent()) {
       options.addAll(
         [
-          SectionOptionDivider,
+          sectionOptionDivider,
           GestureDetector(
             behavior: HitTestBehavior.translucent,
             onTap: () {

--- a/lib/ui/settings/support_section_widget.dart
+++ b/lib/ui/settings/support_section_widget.dart
@@ -43,7 +43,7 @@ class SupportSectionWidget extends StatelessWidget {
           },
           child: SettingsTextItem(text: "Email", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () {
@@ -63,7 +63,7 @@ class SupportSectionWidget extends StatelessWidget {
           },
           child: SettingsTextItem(text: "Roadmap", icon: Icons.navigate_next),
         ),
-        SectionOptionDivider,
+        sectionOptionDivider,
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () async {


### PR DESCRIPTION
Before :
The padding above 'check for updates' is lesser when compared to other fields in 'about'.
![before1](https://user-images.githubusercontent.com/77285023/174972317-4b0a7907-5641-4647-9053-23133c9c0e61.png)

After : 
![after1](https://user-images.githubusercontent.com/77285023/174972349-fb2764df-40b3-49a7-b1ac-e26bb3534ccc.png)

launch() is depreciated, so replaced it with launchUrl()

