### PR TITLE
Switch to ApplicationSupportDirectory for logs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,7 +170,7 @@ Future _runWithLogs(Function() function, {String prefix = ""}) async {
   await SuperLogging.main(
     LogConfig(
       body: function,
-      logDirPath: (await getTemporaryDirectory()).path + "/logs",
+      logDirPath: (await getApplicationSupportDirectory()).path + "/logs",
       maxLogFiles: 5,
       sentryDsn: kDebugMode ? kSentryDebugDSN : kSentryDSN,
       tunnel: kSentryTunnel,

--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -566,7 +566,7 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
     _tabChangedEventSubscription =
         Bus.instance.on<TabChangedEvent>().listen((event) {
       if (event.source != TabChangedEventSource.tab_bar) {
-        _logger.fine('index changed to ${event.selectedIndex}');
+        debugPrint('index changed to ${event.selectedIndex}');
         if (mounted) {
           setState(() {
             currentTabIndex = event.selectedIndex;

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -467,6 +467,8 @@ class FileUploader {
     } catch (e, s) {
       if (!(e is NoActiveSubscriptionError ||
           e is StorageLimitExceededError ||
+          e is WiFiUnavailableError ||
+          e is NoActiveSubscriptionError ||
           e is FileTooLargeForPlanError)) {
         _logger.severe("File upload failed for " + file.toString(), e, s);
       }


### PR DESCRIPTION
## Description
At times, we don't receive complete logs because the OS can clear the logs from temp directory. Switching to ApplicationSupport directory to avoid this. As per current configuration, even in support directory, the logs to be retained for last 5 days.

**getTemporaryDirectory**
```dart
/// Path to the temporary directory on the device that is not backed up and is
/// suitable for storing caches of downloaded files.
///
/// Files in this directory may be cleared at any time. This does *not* return
/// a new temporary directory. Instead, the caller is responsible for creating
/// (and cleaning up) files or directories within this directory. This
/// directory is scoped to the calling application.
///
/// On iOS, this uses the `NSCachesDirectory` API.
///
/// On Android, this uses the `getCacheDir` API on the context.
```

**getApplicationSupportDirectory**
```dart
/// Path to a directory where the application may place application support
/// files.
///
/// Use this for files you don’t want exposed to the user. Your app should not
/// use this directory for user data files.
///
/// On iOS, this uses the `NSApplicationSupportDirectory` API.
/// If this directory does not exist, it is created automatically.
///
/// On Android, this function uses the `getFilesDir` API on the context.
///
/// Throws a `MissingPlatformDirectoryException` if the system is unable to
/// provide the directory.
```
## Test Plan
