### PR TITLE
Update screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 We have open-source apps across Android, iOS, web and desktop that automatically backup your photos and videos.
 
 This repository contains the code for our mobile apps, built with a lot of ❤️, and a little bit of [Flutter.](https://flutter.dev)
-![App Screenshots](https://user-images.githubusercontent.com/1161789/154794909-c391f947-266f-4298-956b-a67b5eb9a169.png)
+
+![App Screenshots](https://user-images.githubusercontent.com/24503581/175218240-fe5a0703-82c1-4750-bfea-abfd9f409a97.png)
+
+<br/>
 
 ## ✨ Features
 
@@ -14,6 +17,7 @@ This repository contains the code for our mobile apps, built with a lot of ❤�
 - Shareable links for albums
 - Highlights of memories from previous years
 - Ability to detect and delete duplicate files
+- Light and dark mode
 - Image editor
 - EXIF viewer
 - Ability to free up disk space by deleting backed up photos
@@ -39,6 +43,7 @@ You can alternatively install the build from PlayStore or F-Droid.
 
 
 ### iOS
+
 <a href="https://apps.apple.com/in/app/ente-photos/id1542026904">
   <img width="197" alt="Download on AppStore" src="https://user-images.githubusercontent.com/1161789/154795157-c4468ff9-97fd-46f3-87fe-dca789d8733a.png">
 </a>
@@ -68,6 +73,6 @@ If you would like to motivate us to keep building, you can do so by [starring](h
 
 ## ❤️ Join the Community
 
-Follow us on [Twitter](https://twitter.com/enteio) and join [r/enteio](https://reddit.com/r/enteio) to get regular updates, connect with other customers, and discuss your ideas.
+Follow us on [Twitter](https://twitter.com/enteio), join [r/enteio](https://reddit.com/r/enteio) or hang out on our [Discord](https://ente.io/discord) to get regular updates, connect with other customers, and discuss your ideas.
 
 An important part of our journey is to build better software by consistently listening to community feedback. Please feel free to [share your thoughts](mailto:feedback@ente.io) with us at any time.


### PR DESCRIPTION
Updated the screenshots. Kept the overall idea the same (three screenshots, bottom clipped, roughly the same height and spacing). Switched from Android to iOS.

Also add light mode feature entry, + link to discord.

@vishnukvmd I tried various variations with/without frames, spacing, drop shadows on devices etc, light=>dark combinations and transitions but none sort of worked so decided to remain with the existing pattern. Variations are in Figma if you wish to take a look.

Pipeline:
- Export PNG from Figma keeping the color space in Display P3
- Optimize the PNG (from 1.5M to .5M, prev image was .2M) using pngquant (`brew install pngquant`).
