### PR TITLE
Handle no element stateError while fetching urls

### DIFF
--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -654,7 +654,16 @@ class FileUploader {
     if (_uploadURLs.isEmpty) {
       await fetchUploadURLs(_queue.length);
     }
-    return _uploadURLs.removeFirst();
+    try {
+      return _uploadURLs.removeFirst();
+    } catch (e, s) {
+      if (e is StateError && e.message == 'No element' && _queue.isNotEmpty) {
+        _logger.warning("Oops, uploadUrls has no element now, fetching again");
+        return _getUploadURL();
+      } else {
+        rethrow;
+      }
+    }
   }
 
   Future<void> _uploadURLFetchInProgress;


### PR DESCRIPTION
## Description
Queue has one element, we wait fetch uploadUrls and track the future using : _uploadURLFetchInProgress which is going to resolve after fetching two URLS 2.
Two more elements are queue and they also wait on the same future.
Now, we have three folks waiting on same future which is only going to return two URLs, which result in this StateError "No Element"

## Test Plan
