### PR TITLE
Sort albums by name during Add/Move/Restore flow

### DIFF
--- a/lib/ui/create_collection_page.dart
+++ b/lib/ui/create_collection_page.dart
@@ -213,8 +213,8 @@ class _CreateCollectionPageState extends State<CreateCollectionPage> {
       }
     }
     collectionsWithThumbnail.sort((first, second) {
-      return second.collection.updationTime
-          .compareTo(first.collection.updationTime);
+      return (first.collection.name ?? "")
+          .compareTo((second.collection.name ?? ""));
     });
     return collectionsWithThumbnail;
   }
@@ -311,9 +311,10 @@ class _CreateCollectionPageState extends State<CreateCollectionPage> {
         fromCollectionID,
         widget.selectedFiles.files?.toList(),
       );
+      await dialog.hide();
       RemoteSyncService.instance.sync(silently: true);
       widget.selectedFiles?.clearAll();
-      await dialog.hide();
+
       return true;
     } on AssertionError catch (e, s) {
       await dialog.hide();


### PR DESCRIPTION
## Description
If user has large number of albums, it's become difficult to destination album when albums are sorted by updationTime.

## Test Plan
- [x] Simulator testing