### PR TITLE
Transition to grand permission screen fix

### DIFF
--- a/lib/ui/backup_folder_selection_page.dart
+++ b/lib/ui/backup_folder_selection_page.dart
@@ -191,7 +191,7 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
                         ),
                       ),
                     )
-                  : Container(),
+                  : const SizedBox.shrink(),
             ],
           ),
         ],

--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -168,7 +168,24 @@ class _HomeWidgetState extends State<HomeWidget> {
         Bus.instance.on<SyncStatusUpdate>().listen((event) async {
       if (mounted &&
           event.status == SyncStatus.completed_first_gallery_import) {
-        setState(() {});
+        Duration delayInRefresh = Duration(milliseconds: 0);
+        // Loading page will redirect to BackupFolderSelectionPage.
+        // To avoid showing folder hook in middle during routing,
+        // delay state refresh for home page
+        if (!LocalSyncService.instance.hasGrantedLimitedPermissions()) {
+          delayInRefresh = Duration(milliseconds: 250);
+        }
+        Future.delayed(
+          delayInRefresh,
+          () => {
+            if (mounted)
+              {
+                setState(
+                  () {},
+                )
+              }
+          },
+        );
       }
     });
     _backupFoldersUpdatedEvent =

--- a/lib/ui/password_reentry_page.dart
+++ b/lib/ui/password_reentry_page.dart
@@ -4,6 +4,7 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/subscription_purchased_event.dart';
 import 'package:photos/ui/common/dynamicFAB.dart';
+import 'package:photos/ui/home_widget.dart';
 import 'package:photos/ui/recovery_page.dart';
 import 'package:photos/utils/dialog_util.dart';
 
@@ -76,7 +77,14 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
           }
           await dialog.hide();
           Bus.instance.fire(SubscriptionPurchasedEvent());
-          Navigator.of(context).popUntil((route) => route.isFirst);
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return HomeWidget();
+              },
+            ),
+            (route) => false,
+          );
         },
       ),
       floatingActionButtonLocation: fabLocation(),

--- a/lib/ui/payment/skip_subscription_widget.dart
+++ b/lib/ui/payment/skip_subscription_widget.dart
@@ -4,6 +4,7 @@ import 'package:photos/events/subscription_purchased_event.dart';
 import 'package:photos/models/billing_plan.dart';
 import 'package:photos/models/subscription.dart';
 import 'package:photos/services/billing_service.dart';
+import 'package:photos/ui/home_widget.dart';
 
 class SkipSubscriptionWidget extends StatelessWidget {
   const SkipSubscriptionWidget({
@@ -31,7 +32,14 @@ class SkipSubscriptionWidget extends StatelessWidget {
         ),
         onPressed: () async {
           Bus.instance.fire(SubscriptionPurchasedEvent());
-          Navigator.of(context).popUntil((route) => route.isFirst);
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return HomeWidget();
+              },
+            ),
+            (route) => false,
+          );
           BillingService.instance
               .verifySubscription(kFreeProductID, "", paymentProvider: "ente");
         },


### PR DESCRIPTION
After : 

https://user-images.githubusercontent.com/77285023/176202234-e7f4e3d4-50d0-4b71-a43b-f32ebc56031a.mov

The transition should be fixed on all devices now. The animation style varies with devices or with android/iOS. In this emulator, the transition animation of screens is zoom-in, and now the grant permission screen also follows the same (it was inverted before).

An unwanted screen flashed between two screens, that has been fixed with the second commit.