### PR TITLE
Android: Mark bgtask as finished if process is already running

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,7 +71,7 @@ Future<void> _runInForeground() async {
 }
 
 Future<void> _runBackgroundTask(String taskId) async {
-  if (Platform.isIOS && _isProcessRunning) {
+  if (_isProcessRunning) {
     _logger.info("Background task triggered when process was already running");
     await _sync('bgTaskActiveProcess');
     BackgroundFetch.finish(taskId);


### PR DESCRIPTION
## Description
This fixes the duplicate log lines issue, which we see on the android.
Please note: If the process is already running, the logs will appear as the process is in the foreground. By looking at the app lifeCycle logs, we can deduce if the process was in background or foreground.
## Test Plan
