### PR TITLE
Fix share to ente upload

### DIFF
--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -76,7 +76,12 @@ class Configuration {
   FlutterSecureStorage _secureStorage;
   String _tempDirectory;
   String _thumbnailCacheDirectory;
-  String _sharedMediaDirectory;
+  // 6th July 22: Remove this after 3 months. Hopefully, active users
+  // will migrate to newer version of the app, where shared media is stored
+  // on appSupport directory which OS won't clean up automatically
+  String _sharedTempMediaDirectory;
+
+  String _sharedDocumentsMediaDirectory;
   String _volatilePassword;
 
   final _secureStorageOptionsIOS =
@@ -106,8 +111,10 @@ class Configuration {
     var tempDirectoryPath = (await getTemporaryDirectory()).path;
     _thumbnailCacheDirectory = tempDirectoryPath + "/thumbnail-cache";
     io.Directory(_thumbnailCacheDirectory).createSync(recursive: true);
-    _sharedMediaDirectory = tempDirectoryPath + "/ente-shared-media";
-    io.Directory(_sharedMediaDirectory).createSync(recursive: true);
+    _sharedTempMediaDirectory = tempDirectoryPath + "/ente-shared-media";
+    io.Directory(_sharedTempMediaDirectory).createSync(recursive: true);
+    _sharedDocumentsMediaDirectory = _documentsDirectory + "/ente-shared-media";
+    io.Directory(_sharedDocumentsMediaDirectory).createSync(recursive: true);
     if (!_preferences.containsKey(tokenKey)) {
       await _secureStorage.deleteAll(iOptions: _secureStorageOptionsIOS);
     } else {
@@ -470,8 +477,12 @@ class Configuration {
     return _thumbnailCacheDirectory;
   }
 
-  String getSharedMediaCacheDirectory() {
-    return _sharedMediaDirectory;
+  String getOldSharedMediaCacheDirectory() {
+    return _sharedTempMediaDirectory;
+  }
+
+  String getSharedMediaDirectory() {
+    return _sharedDocumentsMediaDirectory;
   }
 
   bool hasConfiguredAccount() {

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -15,7 +15,9 @@ const int kGalleryLoadStartTime = -8000000000000000; // Wednesday, March 6, 1748
 const int kGalleryLoadEndTime = 9223372036854775807; // 2^63 -1
 
 // used to identify which ente file are available in app cache
-const String kSharedMediaIdentifier = 'ente-shared://';
+// todo: 6Jun22: delete old media identifier after 3 months
+const String kOldSharedMediaIdentifier = 'ente-shared://';
+const String kSharedMediaIdentifier = 'ente-shared-media://';
 
 const int kMaxLivePhotoToastCount = 2;
 const String kLivePhotoToastCounterKey = "show_live_photo_toast";

--- a/lib/models/file.dart
+++ b/lib/models/file.dart
@@ -222,7 +222,9 @@ class File {
   }
 
   bool isSharedMediaToAppSandbox() {
-    return localID != null && localID.startsWith(kSharedMediaIdentifier);
+    return localID != null &&
+        (localID.startsWith(kOldSharedMediaIdentifier) ||
+            localID.startsWith(kSharedMediaIdentifier));
   }
 
   bool hasLocation() {

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -7,7 +7,6 @@ import 'package:device_info/device_info.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/files_db.dart';
@@ -309,7 +308,8 @@ Future<bool> deleteLocalFiles(
   final List<String> localAssetIDs = [];
   final List<String> localSharedMediaIDs = [];
   for (String id in localIDs) {
-    if (id.startsWith(kSharedMediaIdentifier)) {
+    if (id.startsWith(kOldSharedMediaIdentifier) ||
+        id.startsWith(kSharedMediaIdentifier)) {
       localSharedMediaIDs.add(id);
     } else {
       localAssetIDs.add(id);
@@ -434,9 +434,7 @@ Future<List<String>> _tryDeleteSharedMediaFiles(List<String> localIDs) {
   final List<String> actuallyDeletedIDs = [];
   try {
     return Future.forEach(localIDs, (id) async {
-      String localPath = Configuration.instance.getSharedMediaCacheDirectory() +
-          "/" +
-          id.replaceAll(kSharedMediaIdentifier, '');
+      String localPath = getSharedMediaPathFromLocalID(id);
       try {
         // verify the file exists as the OS may have already deleted it from cache
         if (io.File(localPath).existsSync()) {

--- a/lib/utils/file_util.dart
+++ b/lib/utils/file_util.dart
@@ -86,9 +86,19 @@ Future<io.File> _getLocalDiskFile(
 }
 
 String getSharedMediaFilePath(ente.File file) {
-  return Configuration.instance.getSharedMediaCacheDirectory() +
-      "/" +
-      file.localID.replaceAll(kSharedMediaIdentifier, '');
+  return getSharedMediaPathFromLocalID(file.localID);
+}
+
+String getSharedMediaPathFromLocalID(String localID) {
+  if (localID.startsWith(kOldSharedMediaIdentifier)) {
+    return Configuration.instance.getOldSharedMediaCacheDirectory() +
+        "/" +
+        localID.replaceAll(kOldSharedMediaIdentifier, '');
+  } else {
+    return Configuration.instance.getSharedMediaDirectory() +
+        "/" +
+        localID.replaceAll(kSharedMediaIdentifier, '');
+  }
 }
 
 void preloadThumbnail(ente.File file) {

--- a/lib/utils/share_util.dart
+++ b/lib/utils/share_util.dart
@@ -79,9 +79,7 @@ Future<List<File>> convertIncomingSharedMediaToFile(
     enteFile.title = basename(media.path);
     var ioFile = dartio.File(media.path);
     ioFile = ioFile.renameSync(
-      Configuration.instance.getSharedMediaCacheDirectory() +
-          "/" +
-          enteFile.title,
+      Configuration.instance.getSharedMediaDirectory() + "/" + enteFile.title,
     );
     enteFile.localID = kSharedMediaIdentifier + enteFile.title;
     enteFile.collectionID = collectionID;


### PR DESCRIPTION
## Description
**Issue:** 
 - Unlike other apps, we don't show a blocking progress dialog till the file upload is completed for shared files.
 - Unfortunately, we were copying the shared media file to app's temp directory and uploading it asynchronously along with other files.  
 -nAs the temp directory can be cleaned up by the OS at any time, we can end up losing such files before the upload is completed.

**Fix:** 
-  Instead of copying the file to temp directory, start copying it inside document directory. 
- Clean up the file from the document directory in following two cases: 
      - When upload is finished successfully 
      - User manually delete those files.

## Test Plan
