### PR TITLE
Improve experience for live photo download

### DIFF
--- a/lib/models/ignored_file.dart
+++ b/lib/models/ignored_file.dart
@@ -29,4 +29,9 @@ class IgnoredFile {
       kIgnoreReasonTrash,
     );
   }
+
+  @override
+  String toString() {
+    return 'IgnoredFile{localID: $localID, title: $title, deviceFolder: $deviceFolder, reason: $reason}';
+  }
 }

--- a/lib/ui/viewer/file/zoomable_live_image.dart
+++ b/lib/ui/viewer/file/zoomable_live_image.dart
@@ -130,8 +130,11 @@ class _ZoomableLiveImageState extends State<ZoomableLiveImage>
       return null;
     });
 
+    // FixMe: Here, we are fetching video directly when getFile failed
+    // getFile with liveVideo as true can fail for file with localID when
+    // the live photo was downloaded from remote.
     if ((videoFile == null || !videoFile.existsSync()) &&
-        _file.isRemoteFile()) {
+        _file.uploadedFileID != null) {
       videoFile = await getFileFromServer(widget.file, liveVideo: true)
           .timeout(const Duration(seconds: 15))
           .onError((e, s) {


### PR DESCRIPTION
## Description
- Fixes auto-upload of the video assets by marking it as ignored for auto-upload.

The behaviour is similar to delete from ente only. The user will see the video file under on device folder. But this video will never be auto-uploaded unless user manually select the file and mark for upload. 

> UX Issue (Existing): May be we should indicate in the thumbnail that these assets are intentionally ignored for uploads.

- Fix playback for downloaded live photos. 

As video and image are downloaded as separate assetIDs. In the internal DB, we only keep track of the assetID for image assets. So, fetch for live video for this assetID fails. As fallback, we are reading the video from remote server.
## Test Plan
