### PR TITLE
fixed video duration bug for files sent to ente from device

### DIFF
--- a/lib/utils/share_util.dart
+++ b/lib/utils/share_util.dart
@@ -91,7 +91,7 @@ Future<List<File>> convertIncomingSharedMediaToFile(
         enteFile.creationTime = exifTime.microsecondsSinceEpoch;
       }
     } else if (enteFile.fileType == FileType.video) {
-      enteFile.duration = media.duration ?? 0;
+      enteFile.duration = media.duration ~/ 1000 ?? 0;
     }
     if (enteFile.creationTime == null || enteFile.creationTime == 0) {
       final parsedDateTime =


### PR DESCRIPTION
Initially the duration was stored in milliseconds, now it is stored in seconds just like in other video files.