### PR TITLE
bump version to 0.6.19+349

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: ente photos application
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.6.17+347
+version: 0.6.19+349
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## Description
0.6.18 is already on playstore. Had to upload that version because playstore rejected 0.6.17 after a failed attempt to upload that version.
## Test Plan
