### PR TITLE
Hide Add/Remove/Move options from incoming album

### DIFF
--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -454,7 +454,6 @@ class IncomingCollectionItem extends StatelessWidget {
           CollectionPage(
             c,
             appBarType: GalleryType.sharedCollection,
-            overlayType: GalleryType.sharedCollection,
             tagPrefix: "shared_collection",
           ),
         );

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -454,6 +454,7 @@ class IncomingCollectionItem extends StatelessWidget {
           CollectionPage(
             c,
             appBarType: GalleryType.sharedCollection,
+            overlayType: GalleryType.sharedCollection,
             tagPrefix: "shared_collection",
           ),
         );

--- a/lib/ui/viewer/file/file_info_dialog.dart
+++ b/lib/ui/viewer/file/file_info_dialog.dart
@@ -199,30 +199,31 @@ class _FileInfoWidgetState extends State<FileInfoWidget> {
           ? const DividerWithPadding(left: 70, right: 20)
           : const SizedBox.shrink(),
       ListTile(
-          leading: const Padding(
-            padding: EdgeInsets.only(left: 6),
-            child: Icon(Icons.folder_outlined),
+        leading: const Padding(
+          padding: EdgeInsets.only(left: 6),
+          child: Icon(Icons.folder_outlined),
+        ),
+        title: GestureDetector(
+          onTap: () {
+            if (file.collectionID != null) {
+              Navigator.pop(context); // info dialog
+              Collection c = CollectionsService.instance
+                  .getCollectionByID(file.collectionID);
+              routeToPage(
+                context,
+                CollectionPage(CollectionWithThumbnail(c, null)),
+              );
+            }
+          },
+          child: Text(
+            file.collectionID != null
+                ? CollectionsService.instance
+                    .getCollectionByID(file.collectionID)
+                    .name
+                : file.deviceFolder,
           ),
-          title: GestureDetector(
-            onTap: () {
-              if (file.collectionID != null) {
-                Navigator.pop(context); // info dialog
-                Collection c = CollectionsService.instance
-                    .getCollectionByID(file.collectionID);
-                routeToPage(
-                  context,
-                  CollectionPage(CollectionWithThumbnail(c, null)),
-                );
-              }
-            },
-            child: Text(
-              file.collectionID != null
-                  ? CollectionsService.instance
-                      .getCollectionByID(file.collectionID)
-                      .name
-                  : file.deviceFolder,
-            ),
-          )),
+        ),
+      ),
       const DividerWithPadding(left: 70, right: 20),
       (file.uploadedFileID != null && file.updationTime != null)
           ? ListTile(

--- a/lib/ui/viewer/gallery/collection_page.dart
+++ b/lib/ui/viewer/gallery/collection_page.dart
@@ -14,14 +14,12 @@ class CollectionPage extends StatelessWidget {
   final CollectionWithThumbnail c;
   final String tagPrefix;
   final GalleryType appBarType;
-  final GalleryType overlayType;
   final _selectedFiles = SelectedFiles();
 
   CollectionPage(
     this.c, {
     this.tagPrefix = "collection",
     this.appBarType = GalleryType.ownedCollection,
-    this.overlayType = GalleryType.ownedCollection,
     Key key,
   }) : super(key: key);
 
@@ -67,7 +65,7 @@ class CollectionPage extends StatelessWidget {
         children: [
           gallery,
           GalleryOverlayWidget(
-            overlayType,
+            appBarType,
             _selectedFiles,
             collection: c.collection,
           ),


### PR DESCRIPTION
## Description

## Test Plan
- Tested locally and verified that add/move/remove options were not present when files in the incoming collections are selected.