### PR TITLE
Upgrade button fix + branding widget alignment

### DIFF
--- a/lib/ente_theme_data.dart
+++ b/lib/ente_theme_data.dart
@@ -375,7 +375,7 @@ OutlinedButtonThemeData buildOutlinedButtonThemeData({
         borderRadius: BorderRadius.circular(8),
       ),
       alignment: Alignment.center,
-      padding: const EdgeInsets.fromLTRB(50, 12, 50, 12),
+      padding: const EdgeInsets.fromLTRB(50, 16, 50, 16),
       textStyle: const TextStyle(
         fontWeight: FontWeight.w600,
         fontFamily: 'Inter-SemiBold',

--- a/lib/ui/header_error_widget.dart
+++ b/lib/ui/header_error_widget.dart
@@ -75,7 +75,10 @@ class HeaderErrorWidget extends StatelessWidget {
               height: 52,
               padding: const EdgeInsets.fromLTRB(80, 0, 80, 0),
               child: OutlinedButton(
-                child: const Text("Upgrade"),
+                child: const Text(
+                  "Upgrade",
+                  style: TextStyle(height: 1.1),
+                ),
                 onPressed: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(

--- a/lib/ui/status_bar_widget.dart
+++ b/lib/ui/status_bar_widget.dart
@@ -241,7 +241,7 @@ class BrandingWidget extends StatelessWidget {
       children: [
         Container(
           height: kContainerHeight,
-          padding: const EdgeInsets.only(left: 12),
+          padding: const EdgeInsets.only(left: 12, top: 4),
           child: const Align(
             alignment: Alignment.centerLeft,
             child: Text(


### PR DESCRIPTION
The alignment of the 'ente' branding widget and search icon was off by a little, fixed that and the 'upgrade' text inside the upgrade button on exceeding storage limit was getting cut on the bottom, fixed that too.
