### PR TITLE
Fix GIF playback on iOS

### DIFF
--- a/lib/ui/account/password_reentry_page.dart
+++ b/lib/ui/account/password_reentry_page.dart
@@ -71,8 +71,8 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
               _passwordController.text,
               Configuration.instance.getKeyAttributes(),
             );
-          } catch (e) {
-            Logger("PRP").warning(e);
+          } catch (e, s) {
+            Logger("PRP").severe("Password verification failed", e, s);
             await dialog.hide();
             showErrorDialog(context, "Incorrect password", "Please try again");
             return;

--- a/lib/ui/viewer/file/zoomable_image.dart
+++ b/lib/ui/viewer/file/zoomable_image.dart
@@ -163,7 +163,7 @@ class _ZoomableImageState extends State<ZoomableImage>
       _loadingFinalImage = true;
       getFile(
         _photo,
-        isOrigin: isGIF(), // since playback only happens on origin files
+        isOrigin: _isGIF(), // since playback only happens on origin files
       ).then((file) {
         if (file != null && file.existsSync()) {
           _onFinalImageLoaded(Image.file(file).image);
@@ -216,5 +216,5 @@ class _ZoomableImageState extends State<ZoomableImage>
     }
   }
 
-  bool isGIF() => _photo.getDisplayName().toLowerCase().endsWith(".gif");
+  bool _isGIF() => _photo.getDisplayName().toLowerCase().endsWith(".gif");
 }

--- a/lib/ui/viewer/file/zoomable_image.dart
+++ b/lib/ui/viewer/file/zoomable_image.dart
@@ -161,7 +161,10 @@ class _ZoomableImageState extends State<ZoomableImage>
 
     if (!_loadingFinalImage && !_loadedFinalImage) {
       _loadingFinalImage = true;
-      getFile(_photo).then((file) {
+      getFile(
+        _photo,
+        isOrigin: isGIF(), // since playback only happens on origin files
+      ).then((file) {
         if (file != null && file.existsSync()) {
           _onFinalImageLoaded(Image.file(file).image);
         } else {
@@ -212,4 +215,6 @@ class _ZoomableImageState extends State<ZoomableImage>
       });
     }
   }
+
+  bool isGIF() => _photo.getDisplayName().toLowerCase().endsWith(".gif");
 }

--- a/lib/ui/viewer/file/zoomable_image.dart
+++ b/lib/ui/viewer/file/zoomable_image.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
@@ -163,7 +165,8 @@ class _ZoomableImageState extends State<ZoomableImage>
       _loadingFinalImage = true;
       getFile(
         _photo,
-        isOrigin: _isGIF(), // since playback only happens on origin files
+        isOrigin: Platform.isIOS &&
+            _isGIF(), // since on iOS GIFs playback only when origin-files are loaded
       ).then((file) {
         if (file != null && file.existsSync()) {
           _onFinalImageLoaded(Image.file(file).image);


### PR DESCRIPTION
## Description
On iOS, `originFile` had to be loaded to render a GIF that would playback.

## Test Plan
- [x] Tested locally on iOS