### PR TITLE
Rewrite storeDiff logic to fix matching bugs

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -855,10 +855,8 @@ class FilesDB {
       title,
     ];
     if (Platform.isAndroid) {
-      whereClause =
-          '''($columnUploadedFileID != NULL OR $columnUploadedFileID != -1) 
-           AND ($columnOwnerID = ? OR $columnOwnerID IS NULL) AND $columnLocalID = ? AND 
-           $columnFileType = ? AND $columnTitle=? AND $columnDeviceFolder= ? 
+      whereClause = ''' ($columnOwnerID = ? OR $columnOwnerID IS NULL) AND 
+          $columnLocalID = ? AND $columnFileType = ? AND $columnTitle=? AND $columnDeviceFolder= ? 
            ''';
       whereArgs = [
         ownerID,


### PR DESCRIPTION
## Description

## Test Plan
Tested locally on simulator for following cases
 - Verified correct number of files are visible on app when same file was uploaded twice.
 - Remote to local mapping is happening as expected for iOS
 - Changing timestamp or archive on web is reloading home screen.
