### PR TITLE
iOS: Dismiss toast on tap

### DIFF
--- a/lib/utils/toast_util.dart
+++ b/lib/utils/toast_util.dart
@@ -11,6 +11,7 @@ Future<void> showToast(
   BuildContext context,
   String message, {
   toastLength = Toast.LENGTH_LONG,
+  iOSDismissOnTap = true,
 }) async {
   if (Platform.isAndroid) {
     await Fluttertoast.cancel();
@@ -34,6 +35,7 @@ Future<void> showToast(
       message,
       duration: Duration(seconds: (toastLength == Toast.LENGTH_LONG ? 5 : 2)),
       toastPosition: EasyLoadingToastPosition.bottom,
+      dismissOnTap: iOSDismissOnTap,
     );
   }
 }


### PR DESCRIPTION
## Description
In iOS, toasts don't get dismissed on tap. Sometime the toast blocks/prevents the user from clicking on the widget behind the toast while the toast is visible.
## Test Plan
