### PR TITLE
Provide export compliance answer in project settings

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,6 +60,8 @@
 			<key>NSAllowsArbitraryLoadsInWebContent</key>
 			<true/>
 		</dict>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 		<key>NSFaceIDUsageDescription</key>
 		<string>Please allow ente to lock itself with FaceID or TouchID</string>
 		<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
We've been submitting our BIS self-classification report (also with the new US team account), and can now set this to false. This was, App store connect will not ask us to provide the export compliance answers everytime we upload builds.

<img width="527" alt="Screenshot 2022-09-16 at 1 39 09 PM" src="https://user-images.githubusercontent.com/24503581/190589741-8b72f416-be4a-4885-a200-5a681a0374f1.png">
