### PR TITLE
show favorites on top bug fix

### DIFF
--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -95,6 +95,9 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
         if (second.collection.type == CollectionType.favorites &&
             first.collection.type != CollectionType.favorites) {
           return 1;
+        } else if (first.collection.type == CollectionType.favorites &&
+            second.collection.type != CollectionType.favorites) {
+          return 0;
         }
         if (sortKey == AlbumSortKey.albumName) {
           return compareAsciiLowerCaseNatural(


### PR DESCRIPTION
Favorites album was not on top of the collections gallery, have fixed it now. Now it will be on top for all sort types.
