### PR TITLE
convert to getters

### DIFF
--- a/lib/db/trash_db.dart
+++ b/lib/db/trash_db.dart
@@ -87,7 +87,8 @@ class TrashDB {
 
   // this opens the database (and creates it if it doesn't exist)
   Future<Database> _initDatabase() async {
-    final Directory documentsDirectory = await getApplicationDocumentsDirectory();
+    final Directory documentsDirectory =
+        await getApplicationDocumentsDirectory();
     final String path = join(documentsDirectory.path, _databaseName);
     _logger.info("DB path " + path);
     return await openDatabase(
@@ -263,7 +264,7 @@ class TrashDB {
 
     row[columnLocalID] = trash.localID;
     row[columnCreationTime] = trash.creationTime;
-    row[columnFileMetadata] = jsonEncode(trash.getMetadata());
+    row[columnFileMetadata] = jsonEncode(trash.metadata);
 
     row[columnMMdVersion] = trash.mMdVersion ?? 0;
     row[columnMMdEncodedJson] = trash.mMdEncodedJson ?? '{}';

--- a/lib/models/file.dart
+++ b/lib/models/file.dart
@@ -116,7 +116,7 @@ class File extends EnteFile {
     return type;
   }
 
-  Future<AssetEntity?> getAsset() {
+  Future<AssetEntity?> get getAsset {
     if (localID == null) {
       return Future.value(null);
     }
@@ -156,7 +156,7 @@ class File extends EnteFile {
   Future<Map<String, dynamic>> getMetadataForUpload(
     MediaUploadData mediaUploadData,
   ) async {
-    final asset = await getAsset();
+    final asset = await getAsset;
     // asset can be null for files shared to app
     if (asset != null) {
       fileSubType = asset.subtype;
@@ -172,12 +172,12 @@ class File extends EnteFile {
       }
     }
     hash = mediaUploadData.hashData?.fileHash;
-    return getMetadata();
+    return metadata;
   }
 
-  Map<String, dynamic> getMetadata() {
+  Map<String, dynamic> get metadata {
     final metadata = <String, dynamic>{};
-    metadata["localID"] = isSharedMediaToAppSandbox() ? null : localID;
+    metadata["localID"] = isSharedMediaToAppSandbox ? null : localID;
     metadata["title"] = title;
     metadata["deviceFolder"] = deviceFolder;
     metadata["creationTime"] = creationTime;
@@ -204,7 +204,7 @@ class File extends EnteFile {
     return metadata;
   }
 
-  String getDownloadUrl() {
+  String get downloadUrl {
     final endpoint = Configuration.instance.getHttpEndpoint();
     if (endpoint != kDefaultProductionEndpoint ||
         FeatureFlagService.instance.disableCFWorker()) {
@@ -214,7 +214,7 @@ class File extends EnteFile {
     }
   }
 
-  String getThumbnailUrl() {
+  String get thumbnailUrl {
     final endpoint = Configuration.instance.getHttpEndpoint();
     if (endpoint != kDefaultProductionEndpoint ||
         FeatureFlagService.instance.disableCFWorker()) {
@@ -224,7 +224,7 @@ class File extends EnteFile {
     }
   }
 
-  String getDisplayName() {
+  String get displayName {
     if (pubMagicMetadata != null && pubMagicMetadata!.editedName != null) {
       return pubMagicMetadata!.editedName!;
     }
@@ -233,17 +233,17 @@ class File extends EnteFile {
   }
 
   // returns true if the file isn't available in the user's gallery
-  bool isRemoteFile() {
+  bool get isRemoteFile {
     return localID == null && uploadedFileID != null;
   }
 
-  bool isSharedMediaToAppSandbox() {
+  bool get isSharedMediaToAppSandbox {
     return localID != null &&
         (localID!.startsWith(oldSharedMediaIdentifier) ||
             localID!.startsWith(sharedMediaIdentifier));
   }
 
-  bool hasLocation() {
+  bool get hasLocation {
     return location != null &&
         (location!.longitude != 0 || location!.latitude != 0);
   }
@@ -270,7 +270,7 @@ class File extends EnteFile {
     return generatedID.hashCode ^ uploadedFileID.hashCode ^ localID.hashCode;
   }
 
-  String tag() {
+  String get tag {
     return "local_" +
         localID.toString() +
         ":remote_" +

--- a/lib/models/search/file_search_result.dart
+++ b/lib/models/search/file_search_result.dart
@@ -8,7 +8,7 @@ class FileSearchResult extends SearchResult {
 
   @override
   String name() {
-    return file.getDisplayName();
+    return file.displayName;
   }
 
   @override

--- a/lib/services/local_file_update_service.dart
+++ b/lib/services/local_file_update_service.dart
@@ -114,10 +114,10 @@ class LocalFileUpdateService {
             file.hash != null &&
             (file.hash == uploadData.hashData.fileHash ||
                 file.hash == uploadData.hashData.zipHash)) {
-          _logger.info("Skip file update as hash matched ${file.tag()}");
+          _logger.info("Skip file update as hash matched ${file.tag}");
         } else {
           _logger.info(
-            "Marking for file update as hash did not match ${file.tag()}",
+            "Marking for file update as hash did not match ${file.tag}",
           );
           await FilesDB.instance.updateUploadedFile(
             file.localID,

--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -232,7 +232,7 @@ class SearchService {
     final Map<String, List<File>> resultMap = <String, List<File>>{};
 
     for (File eachFile in allFiles) {
-      final String fileName = eachFile.getDisplayName();
+      final String fileName = eachFile.displayName;
       if (fileName.contains(query)) {
         final String exnType = fileName.split(".").last.toUpperCase();
         if (!resultMap.containsKey(exnType)) {

--- a/lib/ui/backup_folder_selection_page.dart
+++ b/lib/ui/backup_folder_selection_page.dart
@@ -409,7 +409,7 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
             ThumbnailWidget(
               file,
               shouldShowSyncStatus: false,
-              key: Key("backup_selection_widget" + file.tag()),
+              key: Key("backup_selection_widget" + file.tag),
             ),
             Padding(
               padding: const EdgeInsets.all(9),

--- a/lib/ui/collections/collection_item_widget.dart
+++ b/lib/ui/collections/collection_item_widget.dart
@@ -39,12 +39,12 @@ class CollectionItem extends StatelessWidget {
               height: sideOfThumbnail,
               width: sideOfThumbnail,
               child: Hero(
-                tag: "collection" + c.thumbnail.tag(),
+                tag: "collection" + c.thumbnail.tag,
                 child: ThumbnailWidget(
                   c.thumbnail,
                   shouldShowArchiveStatus: c.collection.isArchived(),
                   key: Key(
-                    "collection" + c.thumbnail.tag(),
+                    "collection" + c.thumbnail.tag,
                   ),
                 ),
               ),

--- a/lib/ui/collections/device_folder_icon_widget.dart
+++ b/lib/ui/collections/device_folder_icon_widget.dart
@@ -57,7 +57,7 @@ class DeviceFolderIcon extends StatelessWidget {
                   child: Hero(
                     tag: "device_folder:" +
                         deviceCollection.name +
-                        deviceCollection.thumbnail.tag(),
+                        deviceCollection.thumbnail.tag,
                     child: Stack(
                       children: [
                         ThumbnailWidget(
@@ -66,7 +66,7 @@ class DeviceFolderIcon extends StatelessWidget {
                           key: Key(
                             "device_folder:" +
                                 deviceCollection.name +
-                                deviceCollection.thumbnail.tag(),
+                                deviceCollection.thumbnail.tag,
                           ),
                         ),
                         isBackedUp ? Container() : kUnsyncedIconOverlay,

--- a/lib/ui/create_collection_page.dart
+++ b/lib/ui/create_collection_page.dart
@@ -157,7 +157,7 @@ class _CreateCollectionPageState extends State<CreateCollectionPage> {
               child: SizedBox(
                 height: 64,
                 width: 64,
-                key: Key("collection_item:" + item.thumbnail.tag()),
+                key: Key("collection_item:" + item.thumbnail.tag),
                 child: ThumbnailWidget(item.thumbnail),
               ),
             ),

--- a/lib/ui/huge_listview/lazy_loading_gallery.dart
+++ b/lib/ui/huge_listview/lazy_loading_gallery.dart
@@ -321,7 +321,7 @@ class _LazyLoadingGridViewState extends State<LazyLoadingGridView> {
           child: Stack(
             children: [
               Hero(
-                tag: widget.tag + file.tag(),
+                tag: widget.tag + file.tag,
                 child: ColorFiltered(
                   colorFilter: ColorFilter.mode(
                     Colors.black.withOpacity(
@@ -334,7 +334,7 @@ class _LazyLoadingGridViewState extends State<LazyLoadingGridView> {
                     diskLoadDeferDuration: thumbnailDiskLoadDeferDuration,
                     serverLoadDeferDuration: thumbnailServerLoadDeferDuration,
                     shouldShowLivePhotoOverlay: true,
-                    key: Key(widget.tag + file.tag()),
+                    key: Key(widget.tag + file.tag),
                   ),
                 ),
               ),

--- a/lib/ui/memories_widget.dart
+++ b/lib/ui/memories_widget.dart
@@ -150,11 +150,11 @@ class _MemoryWidgetState extends State<MemoryWidget> {
           width: isSeen ? 60 : 56,
           height: isSeen ? 60 : 56,
           child: Hero(
-            tag: "memories" + memory.file.tag(),
+            tag: "memories" + memory.file.tag,
             child: ThumbnailWidget(
               memory.file,
               shouldShowSyncStatus: false,
-              key: Key("memories" + memory.file.tag()),
+              key: Key("memories" + memory.file.tag),
             ),
           ),
         ),

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -294,10 +294,10 @@ class OutgoingCollectionItem extends StatelessWidget {
                 height: 60,
                 width: 60,
                 child: Hero(
-                  tag: "outgoing_collection" + c.thumbnail.tag(),
+                  tag: "outgoing_collection" + c.thumbnail.tag,
                   child: ThumbnailWidget(
                     c.thumbnail,
-                    key: Key("outgoing_collection" + c.thumbnail.tag()),
+                    key: Key("outgoing_collection" + c.thumbnail.tag),
                   ),
                 ),
               ),
@@ -385,10 +385,10 @@ class IncomingCollectionItem extends StatelessWidget {
               child: Stack(
                 children: [
                   Hero(
-                    tag: "shared_collection" + c.thumbnail.tag(),
+                    tag: "shared_collection" + c.thumbnail.tag,
                     child: ThumbnailWidget(
                       c.thumbnail,
-                      key: Key("shared_collection" + c.thumbnail.tag()),
+                      key: Key("shared_collection" + c.thumbnail.tag),
                     ),
                   ),
                   Align(

--- a/lib/ui/tools/deduplicate_page.dart
+++ b/lib/ui/tools/deduplicate_page.dart
@@ -445,7 +445,7 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
             child: Stack(
               children: [
                 Hero(
-                  tag: "deduplicate_" + file.tag(),
+                  tag: "deduplicate_" + file.tag,
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(4),
                     child: ThumbnailWidget(
@@ -453,7 +453,7 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
                       diskLoadDeferDuration: thumbnailDiskLoadDeferDuration,
                       serverLoadDeferDuration: thumbnailServerLoadDeferDuration,
                       shouldShowLivePhotoOverlay: true,
-                      key: Key("deduplicate_" + file.tag()),
+                      key: Key("deduplicate_" + file.tag),
                     ),
                   ),
                 ),

--- a/lib/ui/tools/editor/image_editor_page.dart
+++ b/lib/ui/tools/editor/image_editor_page.dart
@@ -115,7 +115,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
 
   Widget _buildImage() {
     return Hero(
-      tag: widget.detailPageConfig.tagPrefix + widget.originalFile.tag(),
+      tag: widget.detailPageConfig.tagPrefix + widget.originalFile.tag,
       child: ExtendedImage(
         image: widget.imageProvider,
         extendedImageEditorKey: editorKey,
@@ -350,8 +350,8 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       newFile.creationTime = widget.originalFile.creationTime;
       newFile.collectionID = widget.originalFile.collectionID;
       newFile.location = widget.originalFile.location;
-      if (!newFile.hasLocation() && widget.originalFile.localID != null) {
-        final assetEntity = await widget.originalFile.getAsset();
+      if (!newFile.hasLocation && widget.originalFile.localID != null) {
+        final assetEntity = await widget.originalFile.getAsset;
         if (assetEntity != null) {
           final latLong = await assetEntity.latlngAsync();
           newFile.location = Location(latLong.latitude, latLong.longitude);

--- a/lib/ui/viewer/file/fading_app_bar.dart
+++ b/lib/ui/viewer/file/fading_app_bar.dart
@@ -109,7 +109,7 @@ class FadingAppBarState extends State<FadingAppBar> {
       PopupMenuButton(
         itemBuilder: (context) {
           final List<PopupMenuItem> items = [];
-          if (widget.file.isRemoteFile()) {
+          if (widget.file.isRemoteFile) {
             items.add(
               PopupMenuItem(
                 value: 1,
@@ -317,7 +317,7 @@ class FadingAppBarState extends State<FadingAppBar> {
     if (type == FileType.livePhoto) {
       final io.File liveVideo = await getFileFromServer(file, liveVideo: true);
       if (liveVideo == null) {
-        _logger.warning("Failed to find live video" + file.tag());
+        _logger.warning("Failed to find live video" + file.tag);
       } else {
         final videoTitle = file_path.basenameWithoutExtension(file.title) +
             file_path.extension(liveVideo.path);

--- a/lib/ui/viewer/file/file_info_widget.dart
+++ b/lib/ui/viewer/file/file_info_widget.dart
@@ -136,7 +136,7 @@ class _FileInfoWidgetState extends State<FileInfoWidget> {
                 ),
               ),
         title: Text(
-          file.getDisplayName(),
+          file.displayName,
         ),
         subtitle: Row(
           children: [
@@ -358,7 +358,7 @@ class _FileInfoWidgetState extends State<FileInfoWidget> {
       );
     }
     return FutureBuilder(
-      future: widget.file.getAsset(),
+      future: widget.file.getAsset,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           return Text(

--- a/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/lib/ui/viewer/file/thumbnail_widget.dart
@@ -35,7 +35,7 @@ class ThumbnailWidget extends StatefulWidget {
     this.shouldShowArchiveStatus = false,
     this.diskLoadDeferDuration,
     this.serverLoadDeferDuration,
-  }) : super(key: key ?? Key(file.tag()));
+  }) : super(key: key ?? Key(file.tag));
 
   @override
   State<ThumbnailWidget> createState() => _ThumbnailWidgetState();
@@ -60,7 +60,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     super.dispose();
     Future.delayed(const Duration(milliseconds: 10), () {
       // Cancel request only if the widget has been unmounted
-      if (!mounted && widget.file.isRemoteFile() && !_hasLoadedThumbnail) {
+      if (!mounted && widget.file.isRemoteFile && !_hasLoadedThumbnail) {
         removePendingGetThumbnailRequestIfAny(widget.file);
       }
     });
@@ -76,7 +76,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.file.isRemoteFile()) {
+    if (widget.file.isRemoteFile) {
       _loadNetworkImage();
     } else {
       _loadLocalImage(context);
@@ -160,7 +160,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     getThumbnailFromLocal(widget.file).then((thumbData) async {
       if (thumbData == null) {
         if (widget.file.uploadedFileID != null) {
-          _logger.fine("Removing localID reference for " + widget.file.tag());
+          _logger.fine("Removing localID reference for " + widget.file.tag);
           widget.file.localID = null;
           if (widget.file is TrashFile) {
             TrashDB.instance.update(widget.file);
@@ -170,7 +170,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
           _loadNetworkImage();
         } else {
           if (await doesLocalFileExist(widget.file) == false) {
-            _logger.info("Deleting file " + widget.file.tag());
+            _logger.info("Deleting file " + widget.file.tag);
             FilesDB.instance.deleteLocalFile(widget.file);
             Bus.instance.fire(
               LocalPhotosUpdatedEvent(

--- a/lib/ui/viewer/file/video_widget.dart
+++ b/lib/ui/viewer/file/video_widget.dart
@@ -43,9 +43,9 @@ class _VideoWidgetState extends State<VideoWidget> {
   @override
   void initState() {
     super.initState();
-    if (widget.file.isRemoteFile()) {
+    if (widget.file.isRemoteFile) {
       _loadNetworkVideo();
-    } else if (widget.file.isSharedMediaToAppSandbox()) {
+    } else if (widget.file.isSharedMediaToAppSandbox) {
       final localFile = io.File(getSharedMediaFilePath(widget.file));
       if (localFile.existsSync()) {
         _logger.fine("loading from app cache");
@@ -54,7 +54,7 @@ class _VideoWidgetState extends State<VideoWidget> {
         _loadNetworkVideo();
       }
     } else {
-      widget.file.getAsset().then((asset) async {
+      widget.file.getAsset.then((asset) async {
         if (asset == null || !(await asset.exists)) {
           if (widget.file.uploadedFileID != null) {
             _loadNetworkVideo();
@@ -127,7 +127,7 @@ class _VideoWidgetState extends State<VideoWidget> {
       },
     );
     return VisibilityDetector(
-      key: Key(widget.file.tag()),
+      key: Key(widget.file.tag),
       onVisibilityChanged: (info) {
         if (info.visibleFraction < 1) {
           if (mounted && _chewieController != null) {
@@ -136,7 +136,7 @@ class _VideoWidgetState extends State<VideoWidget> {
         }
       },
       child: Hero(
-        tag: widget.tagPrefix + widget.file.tag(),
+        tag: widget.tagPrefix + widget.file.tag,
         child: contentWithDetector,
       ),
     );

--- a/lib/ui/viewer/file/zoomable_image.dart
+++ b/lib/ui/viewer/file/zoomable_image.dart
@@ -65,7 +65,7 @@ class _ZoomableImageState extends State<ZoomableImage>
 
   @override
   Widget build(BuildContext context) {
-    if (_photo.isRemoteFile()) {
+    if (_photo.isRemoteFile) {
       _loadNetworkImage();
     } else {
       _loadLocalImage(context);
@@ -81,7 +81,7 @@ class _ZoomableImageState extends State<ZoomableImage>
           minScale: PhotoViewComputedScale.contained,
           gaplessPlayback: true,
           heroAttributes: PhotoViewHeroAttributes(
-            tag: widget.tagPrefix + _photo.tag(),
+            tag: widget.tagPrefix + _photo.tag,
           ),
           backgroundDecoration: widget.backgroundDecoration,
         ),
@@ -220,5 +220,5 @@ class _ZoomableImageState extends State<ZoomableImage>
     }
   }
 
-  bool _isGIF() => _photo.getDisplayName().toLowerCase().endsWith(".gif");
+  bool _isGIF() => _photo.displayName.toLowerCase().endsWith(".gif");
 }

--- a/lib/ui/viewer/file/zoomable_live_image.dart
+++ b/lib/ui/viewer/file/zoomable_live_image.dart
@@ -121,14 +121,14 @@ class _ZoomableLiveImageState extends State<ZoomableLiveImage>
       return;
     }
     _isLoadingVideoPlayer = true;
-    if (_file.isRemoteFile() && !(await isFileCached(_file, liveVideo: true))) {
+    if (_file.isRemoteFile && !(await isFileCached(_file, liveVideo: true))) {
       showToast(context, "Downloading...", toastLength: Toast.LENGTH_LONG);
     }
 
     var videoFile = await getFile(widget.file, liveVideo: true)
         .timeout(const Duration(seconds: 15))
         .onError((e, s) {
-      _logger.info("getFile failed ${_file.tag()}", e);
+      _logger.info("getFile failed ${_file.tag}", e);
       return null;
     });
 
@@ -140,7 +140,7 @@ class _ZoomableLiveImageState extends State<ZoomableLiveImage>
       videoFile = await getFileFromServer(widget.file, liveVideo: true)
           .timeout(const Duration(seconds: 15))
           .onError((e, s) {
-        _logger.info("getRemoteFile failed ${_file.tag()}", e);
+        _logger.info("getRemoteFile failed ${_file.tag}", e);
         return null;
       });
     }

--- a/lib/ui/viewer/search/result/search_thumbnail_widget.dart
+++ b/lib/ui/viewer/search/result/search_thumbnail_widget.dart
@@ -17,7 +17,7 @@ class SearchThumbnailWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Hero(
-      tag: tagPrefix + file.tag(),
+      tag: tagPrefix + file.tag,
       child: SizedBox(
         height: 58,
         width: 58,

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -44,7 +44,7 @@ Future<void> deleteFilesFromEverywhere(
       if (!(await _localFileExist(file))) {
         _logger.warning("Already deleted " + file.toString());
         alreadyDeletedIDs.add(file.localID);
-      } else if (file.isSharedMediaToAppSandbox()) {
+      } else if (file.isSharedMediaToAppSandbox) {
         localSharedMediaIDs.add(file.localID);
       } else {
         localAssetIDs.add(file.localID);
@@ -203,7 +203,7 @@ Future<void> deleteFilesOnDeviceOnly(
       if (!(await _localFileExist(file))) {
         _logger.warning("Already deleted " + file.toString());
         alreadyDeletedIDs.add(file.localID);
-      } else if (file.isSharedMediaToAppSandbox()) {
+      } else if (file.isSharedMediaToAppSandbox) {
         localSharedMediaIDs.add(file.localID);
       } else {
         localAssetIDs.add(file.localID);
@@ -420,11 +420,11 @@ Future<List<String>> _deleteLocalFilesInBatches(
 }
 
 Future<bool> _localFileExist(File file) {
-  if (file.isSharedMediaToAppSandbox()) {
+  if (file.isSharedMediaToAppSandbox) {
     final localFile = io.File(getSharedMediaFilePath(file));
     return localFile.exists();
   } else {
-    return file.getAsset().then((asset) {
+    return file.getAsset.then((asset) {
       if (asset == null) {
         return false;
       }

--- a/lib/utils/exif_util.dart
+++ b/lib/utils/exif_util.dart
@@ -19,7 +19,7 @@ Future<Map<String, IfdTag>> getExif(File file) async {
   try {
     final originFile = await getFile(file, isOrigin: true);
     final exif = await readExifFromFile(originFile);
-    if (!file.isRemoteFile() && io.Platform.isIOS) {
+    if (!file.isRemoteFile && io.Platform.isIOS) {
       await originFile.delete();
     }
     return exif;

--- a/lib/utils/file_download_util.dart
+++ b/lib/utils/file_download_util.dart
@@ -27,7 +27,7 @@ Future<io.File> downloadAndDecrypt(
   return Network.instance
       .getDio()
       .download(
-        file.getDownloadUrl(),
+        file.downloadUrl,
         encryptedFilePath,
         options: Options(
           headers: {"X-Auth-Token": Configuration.instance.getToken()},

--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -285,7 +285,7 @@ class FileUploader {
         fileOnDisk.updationTime != -1 &&
         fileOnDisk.collectionID == collectionID;
     if (wasAlreadyUploaded) {
-      debugPrint("File is already uploaded ${fileOnDisk.tag()}");
+      debugPrint("File is already uploaded ${fileOnDisk.tag}");
       return fileOnDisk;
     }
 
@@ -520,8 +520,8 @@ class FileUploader {
     );
     if (sameLocalSameCollection != null) {
       _logger.fine(
-        "sameLocalSameCollection: \n toUpload  ${fileToUpload.tag()} "
-        "\n existing: ${sameLocalSameCollection.tag()}",
+        "sameLocalSameCollection: \n toUpload  ${fileToUpload.tag} "
+        "\n existing: ${sameLocalSameCollection.tag}",
       );
       // should delete the fileToUploadEntry
       await FilesDB.instance.deleteByGeneratedID(fileToUpload.generatedID);
@@ -545,8 +545,8 @@ class FileUploader {
       // update the local id of the existing file and delete the fileToUpload
       // entry
       _logger.fine(
-        "fileMissingLocalButSameCollection: \n toUpload  ${fileToUpload.tag()} "
-        "\n existing: ${fileMissingLocalButSameCollection.tag()}",
+        "fileMissingLocalButSameCollection: \n toUpload  ${fileToUpload.tag} "
+        "\n existing: ${fileMissingLocalButSameCollection.tag}",
       );
       fileMissingLocalButSameCollection.localID = fileToUpload.localID;
       // set localID for the given uploadedID across collections
@@ -572,8 +572,8 @@ class FileUploader {
     );
     if (fileExistsButDifferentCollection != null) {
       _logger.fine(
-        "fileExistsButDifferentCollection: \n toUpload  ${fileToUpload.tag()} "
-        "\n existing: ${fileExistsButDifferentCollection.tag()}",
+        "fileExistsButDifferentCollection: \n toUpload  ${fileToUpload.tag} "
+        "\n existing: ${fileExistsButDifferentCollection.tag}",
       );
       final linkedFile = await CollectionsService.instance
           .linkLocalFileToExistingUploadedFileInAnotherCollection(
@@ -609,7 +609,7 @@ class FileUploader {
       // for upload. Shared Media should only be cleared when the upload
       // succeeds.
       if (io.Platform.isIOS ||
-          (uploadCompleted && file.isSharedMediaToAppSandbox())) {
+          (uploadCompleted && file.isSharedMediaToAppSandbox)) {
         await mediaUploadData.sourceFile.delete();
       }
     }

--- a/lib/utils/file_uploader_util.dart
+++ b/lib/utils/file_uploader_util.dart
@@ -51,7 +51,7 @@ class FileHashData {
 }
 
 Future<MediaUploadData> getUploadDataFromEnteFile(ente.File file) async {
-  if (file.isSharedMediaToAppSandbox()) {
+  if (file.isSharedMediaToAppSandbox) {
     return await _getMediaUploadDataFromAppCache(file);
   } else {
     return await _getMediaUploadDataFromAssetFile(file);
@@ -65,13 +65,12 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(ente.File file) async {
   String fileHash, zipHash;
 
   // The timeouts are to safeguard against https://github.com/CaiJingLong/flutter_photo_manager/issues/467
-  final asset = await file
-      .getAsset()
+  final asset = await file.getAsset
       .timeout(const Duration(seconds: 3))
       .catchError((e) async {
     if (e is TimeoutException) {
       _logger.info("Asset fetch timed out for " + file.toString());
-      return await file.getAsset();
+      return await file.getAsset;
     } else {
       throw e;
     }
@@ -162,7 +161,7 @@ Future<void> _decorateEnteFileData(ente.File file, AssetEntity asset) async {
   }
 
   if (file.title == null || file.title.isEmpty) {
-    _logger.warning("Title was missing ${file.tag()}");
+    _logger.warning("Title was missing ${file.tag}");
     file.title = await asset.titleAsync;
   }
 }

--- a/lib/utils/file_util.dart
+++ b/lib/utils/file_util.dart
@@ -39,10 +39,10 @@ Future<io.File> getFile(
   bool isOrigin = false,
 } // only relevant for live photos
     ) async {
-  if (file.isRemoteFile()) {
+  if (file.isRemoteFile) {
     return getFileFromServer(file, liveVideo: liveVideo);
   } else {
-    final String key = file.tag() + liveVideo.toString() + isOrigin.toString();
+    final String key = file.tag + liveVideo.toString() + isOrigin.toString();
     final cachedFile = FileLruCache.get(key);
     if (cachedFile == null) {
       final diskFile = await _getLocalDiskFile(
@@ -70,7 +70,7 @@ Future<io.File> _getLocalDiskFile(
   bool liveVideo = false,
   bool isOrigin = false,
 }) async {
-  if (file.isSharedMediaToAppSandbox()) {
+  if (file.isSharedMediaToAppSandbox) {
     final localFile = io.File(getSharedMediaFilePath(file));
     return localFile.exists().then((exist) {
       return exist ? localFile : null;
@@ -78,7 +78,7 @@ Future<io.File> _getLocalDiskFile(
   } else if (file.fileType == FileType.livePhoto && liveVideo) {
     return Motionphoto.getLivePhotoFile(file.localID);
   } else {
-    return file.getAsset().then((asset) async {
+    return file.getAsset.then((asset) async {
       if (asset == null || !(await asset.exists)) {
         return null;
       }
@@ -104,7 +104,7 @@ String getSharedMediaPathFromLocalID(String localID) {
 }
 
 void preloadThumbnail(ente.File file) {
-  if (file.isRemoteFile()) {
+  if (file.isRemoteFile) {
     getThumbnailFromServer(file);
   } else {
     getThumbnailFromLocal(file);
@@ -122,8 +122,7 @@ Future<io.File> getFileFromServer(
   final cacheManager = (file.fileType == FileType.video || liveVideo)
       ? VideoCacheManager.instance
       : DefaultCacheManager();
-  final fileFromCache =
-      await cacheManager.getFileFromCache(file.getDownloadUrl());
+  final fileFromCache = await cacheManager.getFileFromCache(file.downloadUrl);
   if (fileFromCache != null) {
     return fileFromCache.file;
   }
@@ -154,7 +153,7 @@ Future<bool> isFileCached(ente.File file, {bool liveVideo = false}) async {
   final cacheManager = (file.fileType == FileType.video || liveVideo)
       ? VideoCacheManager.instance
       : DefaultCacheManager();
-  final fileInfo = await cacheManager.getFileFromCache(file.getDownloadUrl());
+  final fileInfo = await cacheManager.getFileFromCache(file.downloadUrl);
   return fileInfo != null;
 }
 
@@ -222,9 +221,9 @@ Future<_LivePhoto> _downloadLivePhoto(
             await imageFile.delete();
           }
           imageFileCache = await DefaultCacheManager().putFile(
-            file.getDownloadUrl(),
+            file.downloadUrl,
             await imageConvertedFile.readAsBytes(),
-            eTag: file.getDownloadUrl(),
+            eTag: file.downloadUrl,
             maxAge: const Duration(days: 365),
             fileExtension: fileExtension,
           );
@@ -234,9 +233,9 @@ Future<_LivePhoto> _downloadLivePhoto(
           await videoFile.create(recursive: true);
           await videoFile.writeAsBytes(data);
           videoFileCache = await VideoCacheManager.instance.putFile(
-            file.getDownloadUrl(),
+            file.downloadUrl,
             await videoFile.readAsBytes(),
-            eTag: file.getDownloadUrl(),
+            eTag: file.downloadUrl,
             maxAge: const Duration(days: 365),
             fileExtension: fileExtension,
           );
@@ -246,7 +245,7 @@ Future<_LivePhoto> _downloadLivePhoto(
     }
     return _LivePhoto(imageFileCache, videoFileCache);
   }).catchError((e) {
-    _logger.warning("failed to download live photos : ${file.tag()}", e);
+    _logger.warning("failed to download live photos : ${file.tag}", e);
     throw e;
   });
 }
@@ -274,16 +273,16 @@ Future<io.File> _downloadAndCache(
       await decryptedFile.delete();
     }
     final cachedFile = await cacheManager.putFile(
-      file.getDownloadUrl(),
+      file.downloadUrl,
       await outputFile.readAsBytes(),
-      eTag: file.getDownloadUrl(),
+      eTag: file.downloadUrl,
       maxAge: const Duration(days: 365),
       fileExtension: fileExtension,
     );
     await outputFile.delete();
     return cachedFile;
   }).catchError((e) {
-    _logger.warning("failed to download file : ${file.tag()}", e);
+    _logger.warning("failed to download file : ${file.tag}", e);
     throw e;
   });
 }
@@ -309,9 +308,9 @@ Future<Uint8List> compressThumbnail(Uint8List thumbnail) {
 
 Future<void> clearCache(ente.File file) async {
   if (file.fileType == FileType.video) {
-    VideoCacheManager.instance.removeFile(file.getDownloadUrl());
+    VideoCacheManager.instance.removeFile(file.downloadUrl);
   } else {
-    DefaultCacheManager().removeFile(file.getDownloadUrl());
+    DefaultCacheManager().removeFile(file.downloadUrl);
   }
   final cachedThumbnail = io.File(
     Configuration.instance.getThumbnailCacheDirectory() +

--- a/lib/utils/magic_util.dart
+++ b/lib/utils/magic_util.dart
@@ -97,7 +97,7 @@ Future<bool> editFilename(
   File file,
 ) async {
   try {
-    final fileName = file.getDisplayName();
+    final fileName = file.displayName;
     final nameWithoutExt = basenameWithoutExtension(fileName);
     final extName = extension(fileName);
     var result = await showDialog<String>(

--- a/lib/utils/thumbnail_util.dart
+++ b/lib/utils/thumbnail_util.dart
@@ -75,7 +75,7 @@ Future<Uint8List> getThumbnailFromLocal(
     ThumbnailLruCache.put(file, data);
     return data;
   }
-  if (file.isSharedMediaToAppSandbox()) {
+  if (file.isSharedMediaToAppSandbox) {
     //todo:neeraj support specifying size/quality
     return getThumbnailFromInAppCacheFile(file).then((data) {
       if (data != null) {
@@ -84,7 +84,7 @@ Future<Uint8List> getThumbnailFromLocal(
       return data;
     });
   } else {
-    return file.getAsset().then((asset) async {
+    return file.getAsset.then((asset) async {
       if (asset == null || !(await asset.exists)) {
         return null;
       }
@@ -130,7 +130,7 @@ Future<void> _downloadAndDecryptThumbnail(FileDownloadItem item) async {
   Uint8List encryptedThumbnail;
   try {
     encryptedThumbnail = (await Network.instance.getDio().get(
-              file.getThumbnailUrl(),
+              file.thumbnailUrl,
               options: Options(
                 headers: {"X-Auth-Token": Configuration.instance.getToken()},
                 responseType: ResponseType.bytes,


### PR DESCRIPTION
Converted possible methods to getters and removed 'get' from the method names too as recommended here
https://dart.dev/guides/language/effective-dart/design#avoid-starting-a-method-name-with-get

Manual changes were only made to file.dart, all the other changes are due to changing method names in file.dart and those getting reflected in other files.