### PR TITLE
Fix mapping of edited files on Android

### DIFF
--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -445,7 +445,7 @@ class RemoteSyncService {
           remoteDiff.localID,
           remoteDiff.fileType,
           title: remoteDiff.title,
-          deviceFolder: remoteDiff.deviceFolder,
+          deviceFolder: remoteDiff.deviceFolder ?? '',
         );
         if (localFileEntries.isEmpty) {
           // set remote file's localID as null because corresponding local file


### PR DESCRIPTION
## Description
For edited files, we are setting localID but during upload the device Folder is null. 
This is causing exception when we are processing the remote sync event which contains edited file.

## Test Plan
