### PR TITLE
Backup settings

### DIFF
--- a/lib/theme/text_style.dart
+++ b/lib/theme/text_style.dart
@@ -43,7 +43,7 @@ const TextStyle large = TextStyle(
 );
 const TextStyle body = TextStyle(
   fontSize: 16,
-  height: 19.4 / 16.0,
+  height: 20 / 16.0,
   fontWeight: _regularWeight,
   fontFamily: _fontFamily,
 );

--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:photos/theme/ente_theme.dart';
+import 'package:photos/ui/components/captioned_text_widget.dart';
+import 'package:photos/ui/components/icon_button_widget.dart';
+import 'package:photos/ui/components/menu_item_widget.dart';
+import 'package:photos/ui/components/menu_section_description_widget.dart';
+import 'package:photos/ui/components/title_bar_title_widget.dart';
+import 'package:photos/ui/components/title_bar_widget.dart';
+import 'package:photos/ui/components/toggle_switch_widget.dart';
+
+class BackupSettingsScreen extends StatelessWidget {
+  const BackupSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: <Widget>[
+          const TitleBarWidget(
+            flexibleSpaceTitle: TitleBarTitleWidget(
+              title: "Backup settings",
+            ),
+            actionIcons: [
+              IconButtonWidget(
+                icon: Icons.close_outlined,
+                isSecondary: true,
+              ),
+            ],
+          ),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 20),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Column(
+                          children: [
+                            MenuItemWidget(
+                              captionedTextWidget: const CaptionedTextWidget(
+                                title: "Backup over mobile data",
+                              ),
+                              menuItemColor: colorScheme.fillFaint,
+                              trailingSwitch: ToggleSwitchWidget(
+                                value: true,
+                                onChanged: (value) {},
+                              ),
+                              borderRadius: 8,
+                              alignCaptionedTextToLeft: true,
+                              isBottomBorderRadiusRemoved: true,
+                              isGestureDetectorDisabled: true,
+                            ),
+                            const SizedBox(height: 1),
+                            MenuItemWidget(
+                              captionedTextWidget: const CaptionedTextWidget(
+                                title: "Backup videos",
+                              ),
+                              menuItemColor: colorScheme.fillFaint,
+                              trailingSwitch: ToggleSwitchWidget(
+                                value: true,
+                                onChanged: (value) {},
+                              ),
+                              borderRadius: 8,
+                              alignCaptionedTextToLeft: true,
+                              isTopBorderRadiusRemoved: true,
+                              isGestureDetectorDisabled: true,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 24),
+                        Column(
+                          children: [
+                            MenuItemWidget(
+                              captionedTextWidget: const CaptionedTextWidget(
+                                title: "Disable auto lock",
+                              ),
+                              menuItemColor: colorScheme.fillFaint,
+                              trailingSwitch: ToggleSwitchWidget(
+                                value: false,
+                                onChanged: (value) {},
+                              ),
+                              borderRadius: 8,
+                              alignCaptionedTextToLeft: true,
+                              isGestureDetectorDisabled: true,
+                            ),
+                            const MenuSectionDescriptionWidget(
+                              content:
+                                  "Disable the device screen lock when ente is in the foreground and there is a backup in progress. This is normally not needed, but may help big uploads and initial imports of large libraries complete faster.",
+                            )
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+              childCount: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -25,6 +25,7 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
     final colorScheme = getEnteColorScheme(context);
     return Scaffold(
       body: CustomScrollView(
+        primary: false,
         slivers: <Widget>[
           TitleBarWidget(
             flexibleSpaceTitle: const TitleBarTitleWidget(

--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -41,7 +41,8 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
               ),
             ],
           ),
-          SliverList(
+          SliverFixedExtentList(
+            itemExtent: 269,
             delegate: SliverChildBuilderDelegate(
               (context, index) {
                 return Padding(

--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -26,14 +26,17 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
     return Scaffold(
       body: CustomScrollView(
         slivers: <Widget>[
-          const TitleBarWidget(
-            flexibleSpaceTitle: TitleBarTitleWidget(
+          TitleBarWidget(
+            flexibleSpaceTitle: const TitleBarTitleWidget(
               title: "Backup settings",
             ),
             actionIcons: [
               IconButtonWidget(
                 icon: Icons.close_outlined,
                 isSecondary: true,
+                onTap: () {
+                  Navigator.pop(context);
+                },
               ),
             ],
           ),

--- a/lib/ui/components/icon_button_widget.dart
+++ b/lib/ui/components/icon_button_widget.dart
@@ -9,6 +9,9 @@ class IconButtonWidget extends StatefulWidget {
   final IconData icon;
   final bool disableGestureDetector;
   final VoidCallback? onTap;
+  final Color? defaultColor;
+  final Color? pressedColor;
+  final Color? iconColor;
   const IconButtonWidget({
     required this.icon,
     this.isPrimary = false,
@@ -16,6 +19,9 @@ class IconButtonWidget extends StatefulWidget {
     this.isRounded = false,
     this.disableGestureDetector = false,
     this.onTap,
+    this.defaultColor,
+    this.pressedColor,
+    this.iconColor,
     super.key,
   });
 
@@ -40,7 +46,8 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
     }
     final colorTheme = getEnteColorScheme(context);
     iconStateColor ??
-        (iconStateColor = (widget.isRounded ? colorTheme.fillFaint : null));
+        (iconStateColor = widget.defaultColor ??
+            (widget.isRounded ? colorTheme.fillFaint : null));
     return widget.disableGestureDetector
         ? _iconButton(colorTheme)
         : GestureDetector(
@@ -62,8 +69,10 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
       ),
       child: Icon(
         widget.icon,
-        color:
-            widget.isSecondary ? colorTheme.strokeMuted : colorTheme.strokeBase,
+        color: widget.iconColor ??
+            (widget.isSecondary
+                ? colorTheme.strokeMuted
+                : colorTheme.strokeBase),
         size: 24,
       ),
     );
@@ -72,8 +81,8 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
   _onTapDown(details) {
     final colorTheme = getEnteColorScheme(context);
     setState(() {
-      iconStateColor =
-          widget.isRounded ? colorTheme.fillMuted : colorTheme.fillFaint;
+      iconStateColor = widget.pressedColor ??
+          (widget.isRounded ? colorTheme.fillMuted : colorTheme.fillFaint);
     });
   }
 

--- a/lib/ui/components/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget.dart
@@ -19,6 +19,8 @@ class MenuItemWidget extends StatefulWidget {
   final double borderRadius;
   final Color? pressedColor;
   final ExpandableController? expandableController;
+  final bool isBottomBorderRadiusRemoved;
+  final bool isTopBorderRadiusRemoved;
   const MenuItemWidget({
     required this.captionedTextWidget,
     this.isExpandable = false,
@@ -34,6 +36,8 @@ class MenuItemWidget extends StatefulWidget {
     this.borderRadius = 4.0,
     this.pressedColor,
     this.expandableController,
+    this.isBottomBorderRadiusRemoved = false,
+    this.isTopBorderRadiusRemoved = false,
     Key? key,
   }) : super(key: key);
 
@@ -86,7 +90,11 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
     final enteColorScheme = Theme.of(context).colorScheme.enteTheme.colorScheme;
     final borderRadius = Radius.circular(widget.borderRadius);
     final isExpanded = widget.expandableController?.value;
-    final bottomBorderRadius = isExpanded != null && isExpanded
+    final bottomBorderRadius =
+        (isExpanded != null && isExpanded) || widget.isBottomBorderRadiusRemoved
+            ? const Radius.circular(0)
+            : borderRadius;
+    final topBorderRadius = widget.isTopBorderRadiusRemoved
         ? const Radius.circular(0)
         : borderRadius;
     return AnimatedContainer(
@@ -95,8 +103,8 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
       padding: const EdgeInsets.symmetric(horizontal: 12),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.only(
-          topLeft: borderRadius,
-          topRight: borderRadius,
+          topLeft: topBorderRadius,
+          topRight: topBorderRadius,
           bottomLeft: bottomBorderRadius,
           bottomRight: bottomBorderRadius,
         ),

--- a/lib/ui/components/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget.dart
@@ -21,6 +21,8 @@ class MenuItemWidget extends StatefulWidget {
   final ExpandableController? expandableController;
   final bool isBottomBorderRadiusRemoved;
   final bool isTopBorderRadiusRemoved;
+  //disable gesture detector if not used
+  final bool isGestureDetectorDisabled;
   const MenuItemWidget({
     required this.captionedTextWidget,
     this.isExpandable = false,
@@ -38,6 +40,7 @@ class MenuItemWidget extends StatefulWidget {
     this.expandableController,
     this.isBottomBorderRadiusRemoved = false,
     this.isTopBorderRadiusRemoved = false,
+    this.isGestureDetectorDisabled = false,
     Key? key,
   }) : super(key: key);
 
@@ -74,7 +77,7 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return widget.isExpandable
+    return widget.isExpandable || widget.isGestureDetectorDisabled
         ? menuItemWidget(context)
         : GestureDetector(
             onTap: widget.onTap,

--- a/lib/ui/components/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget.dart
@@ -166,7 +166,7 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
 
   void _onTapDown(details) {
     setState(() {
-      menuItemColor = widget.pressedColor;
+      menuItemColor = widget.pressedColor ?? widget.menuItemColor;
     });
   }
 

--- a/lib/ui/components/menu_section_description_widget.dart
+++ b/lib/ui/components/menu_section_description_widget.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:photos/theme/ente_theme.dart';
+
+class MenuSectionDescriptionWidget extends StatelessWidget {
+  final String content;
+  const MenuSectionDescriptionWidget({required this.content, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+      child: Text(
+        content,
+        style: getEnteTextTheme(context)
+            .mini
+            .copyWith(color: getEnteColorScheme(context).textMuted),
+      ),
+    );
+  }
+}

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -11,6 +11,7 @@ import 'package:photos/services/deduplication_service.dart';
 import 'package:photos/services/sync_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/backup_folder_selection_page.dart';
+import 'package:photos/ui/backup_settings_screen.dart';
 import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
@@ -58,6 +59,21 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
             const BackupFolderSelectionPage(
               buttonText: "Backup",
             ),
+          );
+        },
+      ),
+      sectionOptionSpacing,
+      MenuItemWidget(
+        captionedTextWidget: const CaptionedTextWidget(
+          title: "Backup settings",
+        ),
+        pressedColor: getEnteColorScheme(context).fillFaint,
+        trailingIcon: Icons.chevron_right_outlined,
+        trailingIconIsMuted: true,
+        onTap: () {
+          routeToPage(
+            context,
+            const BackupSettingsScreen(),
           );
         },
       ),

--- a/lib/ui/settings/backup_section_widget.dart
+++ b/lib/ui/settings/backup_section_widget.dart
@@ -3,7 +3,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:photos/core/configuration.dart';
 import 'package:photos/ente_theme_data.dart';
 import 'package:photos/models/backup_status.dart';
 import 'package:photos/models/duplicate_files.dart';
@@ -12,11 +11,9 @@ import 'package:photos/services/sync_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/backup_folder_selection_page.dart';
 import 'package:photos/ui/backup_settings_screen.dart';
-import 'package:photos/ui/common/dialogs.dart';
 import 'package:photos/ui/components/captioned_text_widget.dart';
 import 'package:photos/ui/components/expandable_menu_item_widget.dart';
 import 'package:photos/ui/components/menu_item_widget.dart';
-import 'package:photos/ui/components/toggle_switch_widget.dart';
 import 'package:photos/ui/settings/common_settings.dart';
 import 'package:photos/ui/tools/deduplicate_page.dart';
 import 'package:photos/ui/tools/free_space_page.dart';
@@ -78,62 +75,8 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
         },
       ),
       sectionOptionSpacing,
-      MenuItemWidget(
-        captionedTextWidget: const CaptionedTextWidget(
-          title: "Backup over mobile data",
-        ),
-        trailingSwitch: ToggleSwitchWidget(
-          value: Configuration.instance.shouldBackupOverMobileData(),
-          onChanged: (value) async {
-            Configuration.instance.setBackupOverMobileData(value);
-            setState(() {});
-          },
-        ),
-      ),
-      sectionOptionSpacing,
-      MenuItemWidget(
-        captionedTextWidget: const CaptionedTextWidget(
-          title: "Backup videos",
-        ),
-        trailingSwitch: ToggleSwitchWidget(
-          value: Configuration.instance.shouldBackupVideos(),
-          onChanged: (value) async {
-            Configuration.instance.setShouldBackupVideos(value);
-            setState(() {});
-          },
-        ),
-      ),
-      sectionOptionSpacing,
     ];
-    if (Platform.isIOS) {
-      sectionOptions.addAll([
-        MenuItemWidget(
-          captionedTextWidget: const CaptionedTextWidget(
-            title: "Disable auto lock",
-          ),
-          trailingSwitch: ToggleSwitchWidget(
-            value: Configuration.instance.shouldKeepDeviceAwake(),
-            onChanged: (value) async {
-              if (value) {
-                final choice = await showChoiceDialog(
-                  context,
-                  "Disable automatic screen lock when ente is running?",
-                  "This will ensure faster uploads by ensuring your device does not sleep when uploads are in progress.",
-                  firstAction: "No",
-                  secondAction: "Yes",
-                );
-                if (choice != DialogUserChoice.secondChoice) {
-                  return;
-                }
-              }
-              await Configuration.instance.setShouldKeepDeviceAwake(value);
-              setState(() {});
-            },
-          ),
-        ),
-        sectionOptionSpacing,
-      ]);
-    }
+
     sectionOptions.addAll(
       [
         MenuItemWidget(


### PR DESCRIPTION
- Created MenuSectionDescription widget (component).
- Changes to MenuItemWidget to work with the backup settings screen.
- Made Backup settings screen.


![Simulator Screen Shot - iPhone 12 mini - 2022-10-28 at 17 42 40](https://user-images.githubusercontent.com/77285023/198584187-b38a1dbd-2964-489c-ad07-9233e5c4144b.png)


Right now to change the state of the ToggleSwitchWidget, setState is being called from the class in which it is called from, which leads to unnecessary rebuilds of other widgets. Will fix this in the next PR.
