### PR TITLE
Contain rebuilds upon changing ToggleSwitchWidget inside itself

### DIFF
--- a/lib/ui/backup_settings_screen.dart
+++ b/lib/ui/backup_settings_screen.dart
@@ -12,14 +12,9 @@ import 'package:photos/ui/components/title_bar_title_widget.dart';
 import 'package:photos/ui/components/title_bar_widget.dart';
 import 'package:photos/ui/components/toggle_switch_widget.dart';
 
-class BackupSettingsScreen extends StatefulWidget {
+class BackupSettingsScreen extends StatelessWidget {
   const BackupSettingsScreen({super.key});
 
-  @override
-  State<BackupSettingsScreen> createState() => _BackupSettingsScreenState();
-}
-
-class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
@@ -60,12 +55,16 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
                               ),
                               menuItemColor: colorScheme.fillFaint,
                               trailingSwitch: ToggleSwitchWidget(
-                                value: Configuration.instance
-                                    .shouldBackupOverMobileData(),
-                                onChanged: (value) async {
-                                  Configuration.instance
-                                      .setBackupOverMobileData(value);
-                                  setState(() {});
+                                value: () {
+                                  return Configuration.instance
+                                      .shouldBackupOverMobileData();
+                                },
+                                onChanged: () async {
+                                  await Configuration.instance
+                                      .setBackupOverMobileData(
+                                    !Configuration.instance
+                                        .shouldBackupOverMobileData(),
+                                  );
                                 },
                               ),
                               borderRadius: 8,
@@ -80,13 +79,12 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
                               ),
                               menuItemColor: colorScheme.fillFaint,
                               trailingSwitch: ToggleSwitchWidget(
-                                value:
+                                value: () =>
                                     Configuration.instance.shouldBackupVideos(),
-                                onChanged: (value) async {
-                                  Configuration.instance
-                                      .setShouldBackupVideos(value);
-                                  setState(() {});
-                                },
+                                onChanged: () => Configuration.instance
+                                    .setShouldBackupVideos(
+                                  !Configuration.instance.shouldBackupVideos(),
+                                ),
                               ),
                               borderRadius: 8,
                               alignCaptionedTextToLeft: true,
@@ -106,9 +104,15 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
                                     ),
                                     menuItemColor: colorScheme.fillFaint,
                                     trailingSwitch: ToggleSwitchWidget(
-                                      value: Configuration.instance
+                                      value: () => Configuration.instance
                                           .shouldKeepDeviceAwake(),
-                                      onChanged: _autoLockOnChanged,
+                                      onChanged: () {
+                                        return _autoLockOnChanged(
+                                          !Configuration.instance
+                                              .shouldKeepDeviceAwake(),
+                                          context,
+                                        );
+                                      },
                                     ),
                                     borderRadius: 8,
                                     alignCaptionedTextToLeft: true,
@@ -134,7 +138,7 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
     );
   }
 
-  void _autoLockOnChanged(value) async {
+  Future<void> _autoLockOnChanged(value, context) async {
     if (value) {
       final choice = await showChoiceDialog(
         context,
@@ -148,6 +152,5 @@ class _BackupSettingsScreenState extends State<BackupSettingsScreen> {
       }
     }
     await Configuration.instance.setShouldKeepDeviceAwake(value);
-    setState(() {});
   }
 }

--- a/lib/ui/components/toggle_switch_widget.dart
+++ b/lib/ui/components/toggle_switch_widget.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:photos/ente_theme_data.dart';
 
-typedef OnChangedCallBack = void Function(bool);
+typedef OnChangedCallBack = Future<void> Function();
+typedef ValueCallBack = bool Function();
 
 class ToggleSwitchWidget extends StatefulWidget {
-  final bool value;
+  final ValueCallBack value;
   final OnChangedCallBack onChanged;
   const ToggleSwitchWidget({
     required this.value,
@@ -30,8 +31,11 @@ class _ToggleSwitchWidgetState extends State<ToggleSwitchWidget> {
             activeColor: enteColorScheme.primary400,
             inactiveTrackColor: enteColorScheme.fillMuted,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            value: widget.value,
-            onChanged: widget.onChanged,
+            value: widget.value.call(),
+            onChanged: (value) async {
+              await widget.onChanged.call();
+              setState(() {});
+            },
           ),
         ),
       ),


### PR DESCRIPTION
Just passed what was being passed to `value` and `onChanged` properties of `ToggleSwitchWidget` inside callbacks so that it can be reused inside `ToggleSwitchWidget` without creating a new instance of it. The callback will give the updated `value` to the switch now on `setState()` inside `ToggleStateWidget` which is called on `onChanged` of switch.