### PR TITLE
Add lint rule to warn for unawaited futures

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -61,7 +61,7 @@ analyzer:
     cancel_subscriptions: error
 
 
-    unawaited_futures: info # convert to warning after fixing existing issues
+    unawaited_futures: ignore # convert to warning after fixing existing issues
     invalid_dependency: info
     use_build_context_synchronously: ignore # experimental lint, requires many changes
     prefer_interpolation_to_compose_strings: ignore # later too many warnings

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,6 +32,7 @@ linter:
     - directives_ordering
     - always_use_package_imports
     - sort_child_properties_last
+    - unawaited_futures
 
 analyzer:
   errors:
@@ -59,6 +60,8 @@ analyzer:
     unnecessary_const: error
     cancel_subscriptions: error
 
+
+    unawaited_futures: info # convert to warning after fixing existing issues
     invalid_dependency: info
     use_build_context_synchronously: ignore # experimental lint, requires many changes
     prefer_interpolation_to_compose_strings: ignore # later too many warnings

--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -537,7 +537,7 @@ class Configuration {
   Future<void> setBackupOverMobileData(bool value) async {
     await _preferences.setBool(keyShouldBackupOverMobileData, value);
     if (value) {
-      SyncService.instance.sync();
+      SyncService.instance.sync().ignore();
     }
   }
 
@@ -562,7 +562,7 @@ class Configuration {
   Future<void> setShouldBackupVideos(bool value) async {
     await _preferences.setBool(keyShouldBackupVideos, value);
     if (value) {
-      SyncService.instance.sync();
+      SyncService.instance.sync().ignore();
     } else {
       SyncService.instance.onVideoBackupPaused();
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -188,7 +188,9 @@ Future _runWithLogs(Function() function, {String prefix = ""}) async {
 }
 
 Future<void> _scheduleHeartBeat(
-    SharedPreferences prefs, bool isBackground) async {
+  SharedPreferences prefs,
+  bool isBackground,
+) async {
   await prefs.setInt(
     isBackground ? kLastBGTaskHeartBeatTime : kLastFGTaskHeartBeatTime,
     DateTime.now().microsecondsSinceEpoch,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,7 +60,7 @@ Future<void> _runInForeground() async {
   return await _runWithLogs(() async {
     _logger.info("Starting app in foreground");
     await _init(false, via: 'mainMethod');
-    _scheduleFGSync('appStart in FG');
+    unawaited(_scheduleFGSync('appStart in FG'));
     runApp(
       AppLock(
         builder: (args) => const EnteApp(_runBackgroundTask, _killBGTask),
@@ -203,7 +203,7 @@ Future<void> _scheduleHeartBeat(
 Future<void> _scheduleFGSync(String caller) async {
   await _sync(caller);
   Future.delayed(kFGSyncFrequency, () async {
-    _scheduleFGSync('fgSyncCron');
+    unawaited(_scheduleFGSync('fgSyncCron'));
   });
 }
 

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -249,12 +249,12 @@ class CollectionsService {
       _collectionIDToCollections[collectionID]
           .sharees
           .removeWhere((user) => user.email == email);
-      _db.insert([_collectionIDToCollections[collectionID]]);
+      unawaited(_db.insert([_collectionIDToCollections[collectionID]]));
     } catch (e) {
       _logger.severe(e);
       rethrow;
     }
-    RemoteSyncService.instance.sync(silently: true);
+    RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
   Future<void> trashCollection(Collection collection) async {
@@ -279,7 +279,7 @@ class CollectionsService {
       await _filesDB.deleteCollection(collection.id);
       final deletedCollection = collection.copyWith(isDeleted: true);
       _collectionIDToCollections[collection.id] = deletedCollection;
-      _db.insert([deletedCollection]);
+      unawaited(_db.insert([deletedCollection]));
       unawaited(LocalSyncService.instance.syncAll());
     } catch (e) {
       _logger.severe('failed to trash collection', e);
@@ -857,7 +857,7 @@ class CollectionsService {
     await _filesDB.removeFromCollection(collectionID, params["fileIDs"]);
     Bus.instance.fire(CollectionUpdatedEvent(collectionID, files));
     Bus.instance.fire(LocalPhotosUpdatedEvent(files));
-    RemoteSyncService.instance.sync(silently: true);
+    RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
   Future<Collection> createAndCacheCollection(

--- a/lib/services/user_remote_flag_service.dart
+++ b/lib/services/user_remote_flag_service.dart
@@ -30,13 +30,13 @@ class UserRemoteFlagService {
   bool shouldShowRecoveryVerification() {
     if (!_prefs.containsKey(needRecoveryKeyVerification)) {
       // fetch the status from remote
-      unawaited(_refreshRecoveryVerificationFlag());
+      _refreshRecoveryVerificationFlag().ignore();
       return false;
     } else {
       final bool shouldShow = _prefs.getBool(needRecoveryKeyVerification)!;
       if (shouldShow) {
         // refresh the status to check if user marked it as done on another device
-        unawaited(_refreshRecoveryVerificationFlag());
+        _refreshRecoveryVerificationFlag().ignore();
       }
       return shouldShow;
     }

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -531,7 +531,7 @@ class UserService {
       );
     } catch (e) {
       await dialog.hide();
-      showErrorDialog(
+      await showErrorDialog(
         context,
         "Incorrect recovery key",
         "The recovery key you entered is incorrect",

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,5 +1,6 @@
 // @dart=2.9
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
@@ -40,6 +41,7 @@ class UserService {
   ValueNotifier<String> emailValueNotifier;
 
   UserService._privateConstructor();
+
   static final UserService instance = UserService._privateConstructor();
 
   Future<void> init() async {
@@ -62,32 +64,40 @@ class UserService {
       );
       await dialog.hide();
       if (response != null && response.statusCode == 200) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (BuildContext context) {
-              return OTTVerificationPage(
-                email,
-                isChangeEmail: isChangeEmail,
-                isCreateAccountScreen: isCreateAccountScreen,
-              );
-            },
+        unawaited(
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return OTTVerificationPage(
+                  email,
+                  isChangeEmail: isChangeEmail,
+                  isCreateAccountScreen: isCreateAccountScreen,
+                );
+              },
+            ),
           ),
         );
         return;
       }
-      showGenericErrorDialog(context);
+      unawaited(showGenericErrorDialog(context));
     } on DioError catch (e) {
       await dialog.hide();
       _logger.info(e);
       if (e.response != null && e.response.statusCode == 403) {
-        showErrorDialog(context, "Oops", "This email is already in use");
+        unawaited(
+          showErrorDialog(
+            context,
+            "Oops",
+            "This email is already in use",
+          ),
+        );
       } else {
-        showGenericErrorDialog(context);
+        unawaited(showGenericErrorDialog(context));
       }
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      showGenericErrorDialog(context);
+      unawaited(showGenericErrorDialog(context));
     }
   }
 
@@ -595,11 +605,13 @@ class UserService {
     try {
       final response = await _enteDio.post("/users/two-factor/setup");
       await dialog.hide();
-      routeToPage(
-        context,
-        TwoFactorSetupPage(
-          response.data["secretCode"],
-          response.data["qrCode"],
+      unawaited(
+        routeToPage(
+          context,
+          TwoFactorSetupPage(
+            response.data["secretCode"],
+            response.data["qrCode"],
+          ),
         ),
       );
     } catch (e) {
@@ -672,11 +684,16 @@ class UserService {
       );
       Bus.instance.fire(TwoFactorStatusChangeEvent(false));
       await dialog.hide();
-      showToast(context, "Two-factor authentication has been disabled");
+      unawaited(
+        showToast(
+          context,
+          "Two-factor authentication has been disabled",
+        ),
+      );
     } catch (e) {
       await dialog.hide();
       _logger.severe("Failed to disabled 2FA", e);
-      showErrorDialog(
+      await showErrorDialog(
         context,
         "Something went wrong",
         "Please contact support if the problem persists",

--- a/lib/ui/account/password_reentry_page.dart
+++ b/lib/ui/account/password_reentry_page.dart
@@ -1,5 +1,7 @@
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
@@ -128,13 +130,15 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
           }
           await dialog.hide();
           Bus.instance.fire(SubscriptionPurchasedEvent());
-          Navigator.of(context).pushAndRemoveUntil(
-            MaterialPageRoute(
-              builder: (BuildContext context) {
-                return const HomeWidget();
-              },
+          unawaited(
+            Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(
+                builder: (BuildContext context) {
+                  return const HomeWidget();
+                },
+              ),
+              (route) => false,
             ),
-            (route) => false,
           );
         },
       ),

--- a/lib/ui/collections/trash_button_widget.dart
+++ b/lib/ui/collections/trash_button_widget.dart
@@ -116,7 +116,7 @@ class _TrashButtonWidgetState extends State<TrashButtonWidget> {
           ),
         ),
       ),
-      onPressed: () async {
+      onPressed: () {
         routeToPage(
           context,
           TrashPage(),

--- a/lib/ui/home/preserve_footer_widget.dart
+++ b/lib/ui/home/preserve_footer_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/services/local_sync_service.dart';
@@ -17,10 +19,12 @@ class PreserveFooterWidget extends StatelessWidget {
           if (LocalSyncService.instance.hasGrantedLimitedPermissions()) {
             await PhotoManager.presentLimited();
           } else {
-            routeToPage(
-              context,
-              const BackupFolderSelectionPage(
-                buttonText: "Preserve",
+            unawaited(
+              routeToPage(
+                context,
+                const BackupFolderSelectionPage(
+                  buttonText: "Preserve",
+                ),
               ),
             );
           }

--- a/lib/ui/payment/child_subscription_widget.dart
+++ b/lib/ui/payment/child_subscription_widget.dart
@@ -136,10 +136,10 @@ class ChildSubscriptionWidget extends StatelessWidget {
     await dialog.show();
     try {
       await UserService.instance.leaveFamilyPlan();
-      dialog.hide();
+      await dialog.hide();
       Navigator.of(context).pop('');
     } catch (e) {
-      dialog.hide();
+      await dialog.hide();
       showGenericErrorDialog(context);
     }
   }

--- a/lib/ui/settings/about_section_widget.dart
+++ b/lib/ui/settings/about_section_widget.dart
@@ -117,7 +117,7 @@ class AboutMenuItemWidget extends StatelessWidget {
       pressedColor: getEnteColorScheme(context).fillFaint,
       trailingIcon: Icons.chevron_right_outlined,
       trailingIconIsMuted: true,
-      onTap: () async {
+      onTap: () {
         Navigator.of(context).push(
           MaterialPageRoute(
             builder: (BuildContext context) {

--- a/lib/ui/settings/account_section_widget.dart
+++ b/lib/ui/settings/account_section_widget.dart
@@ -1,5 +1,7 @@
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_sodium/flutter_sodium.dart';
 import 'package:photos/services/local_authentication_service.dart';
@@ -49,16 +51,18 @@ class AccountSectionWidget extends StatelessWidget {
               try {
                 recoveryKey = await _getOrCreateRecoveryKey(context);
               } catch (e) {
-                showGenericErrorDialog(context);
+                await showGenericErrorDialog(context);
                 return;
               }
-              routeToPage(
-                context,
-                RecoveryKeyPage(
-                  recoveryKey,
-                  "OK",
-                  showAppBar: true,
-                  onDone: () {},
+              unawaited(
+                routeToPage(
+                  context,
+                  RecoveryKeyPage(
+                    recoveryKey,
+                    "OK",
+                    showAppBar: true,
+                    onDone: () {},
+                  ),
                 ),
               );
             }

--- a/lib/ui/settings/danger_section_widget.dart
+++ b/lib/ui/settings/danger_section_widget.dart
@@ -91,7 +91,7 @@ class DangerSectionWidget extends StatelessWidget {
       ],
     );
 
-    showDialog(
+    await showDialog(
       context: context,
       builder: (BuildContext context) {
         return alert;

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -83,7 +83,8 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
                           );
                           if (hasAuthenticated) {
                             if (!snapshot.data) {
-                              UserService.instance.setupTwoFactor(context);
+                              await UserService.instance
+                                  .setupTwoFactor(context);
                             } else {
                               _disableTwoFactor();
                             }
@@ -151,11 +152,13 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
             "Please authenticate to view your active sessions",
           );
           if (hasAuthenticated) {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (BuildContext context) {
-                  return const SessionsPage();
-                },
+            unawaited(
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (BuildContext context) {
+                    return const SessionsPage();
+                  },
+                ),
               ),
             );
           }

--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -265,7 +265,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
         ],
       );
 
-      showDialog(
+      await showDialog(
         context: context,
         builder: (BuildContext context) {
           return alert;

--- a/lib/ui/viewer/gallery/gallery_overlay_widget.dart
+++ b/lib/ui/viewer/gallery/gallery_overlay_widget.dart
@@ -246,14 +246,16 @@ class _OverlayWidgetState extends State<OverlayWidget> {
   }
 
   Future<void> _moveFiles() async {
-    Navigator.push(
-      context,
-      PageTransition(
-        type: PageTransitionType.bottomToTop,
-        child: CreateCollectionPage(
-          widget.selectedFiles,
-          null,
-          actionType: CollectionActionType.moveFiles,
+    unawaited(
+      Navigator.push(
+        context,
+        PageTransition(
+          type: PageTransitionType.bottomToTop,
+          child: CreateCollectionPage(
+            widget.selectedFiles,
+            null,
+            actionType: CollectionActionType.moveFiles,
+          ),
         ),
       ),
     );

--- a/lib/utils/thumbnail_util.dart
+++ b/lib/utils/thumbnail_util.dart
@@ -162,7 +162,8 @@ Future<void> _downloadAndDecryptThumbnail(FileDownloadItem item) async {
   if (cachedThumbnail.existsSync()) {
     await cachedThumbnail.delete();
   }
-  cachedThumbnail.writeAsBytes(data);
+  // data is already cached in-memory, no need to await on dist write
+  unawaited(cachedThumbnail.writeAsBytes(data));
   if (_map.containsKey(file.uploadedFileID)) {
     try {
       item.completer.complete(data);


### PR DESCRIPTION
## Description
For the futures on which we don't want to wait on, we can either wrap them inside `unawaited` or use `.ignore()` extension.

With `unawaited`, if the future fails, then Flutter framework logs a very large stack trace. When we user .ignore(), the failed future won't trigger any additional logs except whatever the application is logging explicitly.   

https://api.flutter.dev/flutter/dart-async/unawaited.html
https://api.flutter.dev/flutter/dart-async/FutureExtensions/ignore.html

## Test Plan
