### PR TITLE
Logging improvements

### DIFF
--- a/lib/db/files_db.dart
+++ b/lib/db/files_db.dart
@@ -623,7 +623,6 @@ class FilesDB {
       limit: limit,
     );
     final files = convertToFiles(results);
-    _logger.info("Fetched " + files.length.toString() + " files");
     return FileLoadResult(files, files.length == limit);
   }
 

--- a/lib/events/collection_updated_event.dart
+++ b/lib/events/collection_updated_event.dart
@@ -5,6 +5,10 @@ import 'package:photos/events/files_updated_event.dart';
 class CollectionUpdatedEvent extends FilesUpdatedEvent {
   final int collectionID;
 
-  CollectionUpdatedEvent(this.collectionID, updatedFiles, {type})
-      : super(updatedFiles, type: type ?? EventType.addedOrUpdated);
+  CollectionUpdatedEvent(this.collectionID, updatedFiles, source, {type})
+      : super(
+          updatedFiles,
+          type: type ?? EventType.addedOrUpdated,
+          source: source ?? "",
+        );
 }

--- a/lib/events/event.dart
+++ b/lib/events/event.dart
@@ -1,3 +1,3 @@
-
-
-class Event {}
+class Event {
+  String get reason => toString();
+}

--- a/lib/events/files_updated_event.dart
+++ b/lib/events/files_updated_event.dart
@@ -6,11 +6,16 @@ import 'package:photos/models/file.dart';
 class FilesUpdatedEvent extends Event {
   final List<File> updatedFiles;
   final EventType type;
+  final String source;
 
   FilesUpdatedEvent(
     this.updatedFiles, {
     this.type = EventType.addedOrUpdated,
+    this.source = "",
   });
+
+  @override
+  String get reason => '${toString()}{type: ${type.name}, "via": $source}';
 }
 
 enum EventType {

--- a/lib/events/force_reload_home_gallery_event.dart
+++ b/lib/events/force_reload_home_gallery_event.dart
@@ -1,7 +1,12 @@
-
-
 import 'package:photos/events/event.dart';
 
 class ForceReloadHomeGalleryEvent extends Event {
-  ForceReloadHomeGalleryEvent();
+  final String message;
+
+  ForceReloadHomeGalleryEvent(this.message);
+
+  @override
+  String toString() {
+    return 'ForceReloadHomeGalleryEvent{message: $message}';
+  }
 }

--- a/lib/events/force_reload_home_gallery_event.dart
+++ b/lib/events/force_reload_home_gallery_event.dart
@@ -6,7 +6,5 @@ class ForceReloadHomeGalleryEvent extends Event {
   ForceReloadHomeGalleryEvent(this.message);
 
   @override
-  String toString() {
-    return 'ForceReloadHomeGalleryEvent{message: $message}';
-  }
+  String get reason => 'ForceReloadHomeGalleryEvent - $message';
 }

--- a/lib/events/local_photos_updated_event.dart
+++ b/lib/events/local_photos_updated_event.dart
@@ -1,8 +1,10 @@
-
-
 import 'package:photos/events/files_updated_event.dart';
 
 class LocalPhotosUpdatedEvent extends FilesUpdatedEvent {
-  LocalPhotosUpdatedEvent(updatedFiles, {type})
-      : super(updatedFiles, type: type ?? EventType.addedOrUpdated);
+  LocalPhotosUpdatedEvent(updatedFiles, {type, source})
+      : super(
+          updatedFiles,
+          type: type ?? EventType.addedOrUpdated,
+          source: source ?? "",
+        );
 }

--- a/lib/services/collections_service.dart
+++ b/lib/services/collections_service.dart
@@ -755,7 +755,7 @@ class CollectionsService {
         await _filesDB.deleteUnSyncedLocalFiles(localIDs);
       }
       // Force reload home gallery to pull in the restored files
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("restoredFromTrash"));
     } catch (e, s) {
       _logger.severe("failed to restore files", e, s);
       rethrow;

--- a/lib/services/favorites_service.dart
+++ b/lib/services/favorites_service.dart
@@ -46,7 +46,8 @@ class FavoritesService {
     if (file.uploadedFileID == null) {
       file.collectionID = collectionID;
       await _filesDB.insert(file);
-      Bus.instance.fire(CollectionUpdatedEvent(collectionID, [file]));
+      Bus.instance
+          .fire(CollectionUpdatedEvent(collectionID, [file], "addTFav"));
     } else {
       await _collectionsService.addToCollection(collectionID, [file]);
     }

--- a/lib/services/file_magic_service.dart
+++ b/lib/services/file_magic_service.dart
@@ -36,7 +36,7 @@ class FileMagicService {
     await _updateMagicData(files, update);
     if (visibility == visibilityVisible) {
       // Force reload home gallery to pull in the now unarchived files
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("unarchivedFiles"));
       Bus.instance
           .fire(LocalPhotosUpdatedEvent(files, type: EventType.unarchived));
     } else {

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -77,7 +77,11 @@ extension HiddenService on CollectionsService {
       }
       Bus.instance.fire(ForceReloadHomeGalleryEvent("hideFiles"));
       Bus.instance.fire(
-        LocalPhotosUpdatedEvent(filesToHide, type: EventType.unarchived),
+        LocalPhotosUpdatedEvent(
+          filesToHide,
+          type: EventType.hide,
+          source: "hideFiles",
+        ),
       );
 
       await dialog.hide();

--- a/lib/services/hidden_service.dart
+++ b/lib/services/hidden_service.dart
@@ -75,7 +75,7 @@ extension HiddenService on CollectionsService {
         }
         await move(defaultHiddenCollection.id, entry.key, entry.value);
       }
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("hideFiles"));
       Bus.instance.fire(
         LocalPhotosUpdatedEvent(filesToHide, type: EventType.unarchived),
       );

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -325,8 +325,8 @@ class RemoteSyncService {
       }
     }
     if (moreFilesMarkedForBackup && !_config.hasSelectedAllFoldersForBackup()) {
-      debugPrint("force reload due to display new files");
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      // "force reload due to display new files"
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("newFilesDisplay"));
     }
   }
 
@@ -688,8 +688,8 @@ class RemoteSyncService {
           " remoteFiles seen first time",
     );
     if (needsGalleryReload) {
-      _logger.fine('force reload home gallery');
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      // 'force reload home gallery'
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("remoteSync"));
     }
   }
 

--- a/lib/services/remote_sync_service.dart
+++ b/lib/services/remote_sync_service.dart
@@ -209,6 +209,7 @@ class RemoteSyncService {
         CollectionUpdatedEvent(
           collectionID,
           deletedFiles,
+          "syncDeleteFromRemote",
           type: EventType.deletedFromRemote,
         ),
       );
@@ -216,6 +217,7 @@ class RemoteSyncService {
         LocalPhotosUpdatedEvent(
           deletedFiles,
           type: EventType.deletedFromRemote,
+          source: "syncDeleteFromRemote",
         ),
       );
     }
@@ -227,9 +229,19 @@ class RemoteSyncService {
             " files in collection " +
             collectionID.toString(),
       );
-      Bus.instance.fire(LocalPhotosUpdatedEvent(diff.updatedFiles));
-      Bus.instance
-          .fire(CollectionUpdatedEvent(collectionID, diff.updatedFiles));
+      Bus.instance.fire(
+        LocalPhotosUpdatedEvent(
+          diff.updatedFiles,
+          source: "syncUpdateFromRemote",
+        ),
+      );
+      Bus.instance.fire(
+        CollectionUpdatedEvent(
+          collectionID,
+          diff.updatedFiles,
+          "syncUpdateFromRemote",
+        ),
+      );
     }
 
     if (diff.latestUpdatedAtTime > 0) {
@@ -516,7 +528,9 @@ class RemoteSyncService {
   }
 
   Future<void> _onFileUploaded(File file) async {
-    Bus.instance.fire(CollectionUpdatedEvent(file.collectionID, [file]));
+    Bus.instance.fire(
+      CollectionUpdatedEvent(file.collectionID, [file], "fileUpload"),
+    );
     _completedUploads++;
     final toBeUploadedInThisSession = _uploader.getCurrentSessionUploadCount();
     if (toBeUploadedInThisSession == 0) {

--- a/lib/services/trash_sync_service.dart
+++ b/lib/services/trash_sync_service.dart
@@ -72,8 +72,13 @@ class TrashSyncService {
       return await syncTrash();
     } else if (diff.trashedFiles.isNotEmpty ||
         diff.deletedUploadIDs.isNotEmpty) {
-      _logger.fine('refresh gallery');
-      Bus.instance.fire(CollectionUpdatedEvent(0, <File>[]));
+      Bus.instance.fire(
+        CollectionUpdatedEvent(
+          0,
+          <File>[],
+          "trash_change",
+        ),
+      );
     }
   }
 

--- a/lib/ui/collections_gallery_widget.dart
+++ b/lib/ui/collections_gallery_widget.dart
@@ -33,7 +33,7 @@ class CollectionsGalleryWidget extends StatefulWidget {
 
 class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
     with AutomaticKeepAliveClientMixin {
-  final _logger = Logger("CollectionsGallery");
+  final _logger = Logger((_CollectionsGalleryWidgetState).toString());
   StreamSubscription<LocalPhotosUpdatedEvent> _localFilesSubscription;
   StreamSubscription<CollectionUpdatedEvent> _collectionUpdatesSubscription;
   StreamSubscription<UserLoggedOutEvent> _loggedOutEvent;
@@ -44,16 +44,16 @@ class _CollectionsGalleryWidgetState extends State<CollectionsGalleryWidget>
   void initState() {
     _localFilesSubscription =
         Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {
-      _loadReason = (LocalPhotosUpdatedEvent).toString();
+      _loadReason = event.reason;
       setState(() {});
     });
     _collectionUpdatesSubscription =
         Bus.instance.on<CollectionUpdatedEvent>().listen((event) {
-      _loadReason = (CollectionUpdatedEvent).toString();
+      _loadReason = event.reason;
       setState(() {});
     });
     _loggedOutEvent = Bus.instance.on<UserLoggedOutEvent>().listen((event) {
-      _loadReason = (UserLoggedOutEvent).toString();
+      _loadReason = event.reason;
       setState(() {});
     });
     sortKey = LocalSettings.instance.albumSortKey();

--- a/lib/ui/huge_listview/lazy_loading_gallery.dart
+++ b/lib/ui/huge_listview/lazy_loading_gallery.dart
@@ -98,7 +98,7 @@ class _LazyLoadingGalleryState extends State<LazyLoadingGallery> {
       if (kDebugMode) {
         _logger.info(
           filesUpdatedThisDay.length.toString() +
-              " files were updated due to ${event.type} on " +
+              " files were updated due to ${event.type.name} on " +
               getDayTitle(galleryDate.microsecondsSinceEpoch),
         );
       }

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -45,11 +45,12 @@ class _SharedCollectionGalleryState extends State<SharedCollectionGallery>
   void initState() {
     _localFilesSubscription =
         Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {
-      _logger.info("Files updated");
+      debugPrint("SetState Shared Collections on LocalPhotosUpdatedEvent");
       setState(() {});
     });
     _collectionUpdatesSubscription =
         Bus.instance.on<CollectionUpdatedEvent>().listen((event) {
+      debugPrint("SetState Shared Collections on CollectionUpdatedEvent");
       setState(() {});
     });
     _loggedOutEvent = Bus.instance.on<UserLoggedOutEvent>().listen((event) {

--- a/lib/ui/shared_collections_gallery.dart
+++ b/lib/ui/shared_collections_gallery.dart
@@ -45,12 +45,12 @@ class _SharedCollectionGalleryState extends State<SharedCollectionGallery>
   void initState() {
     _localFilesSubscription =
         Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {
-      debugPrint("SetState Shared Collections on LocalPhotosUpdatedEvent");
+      debugPrint("SetState Shared Collections on ${event.reason}");
       setState(() {});
     });
     _collectionUpdatesSubscription =
         Bus.instance.on<CollectionUpdatedEvent>().listen((event) {
-      debugPrint("SetState Shared Collections on CollectionUpdatedEvent");
+      debugPrint("SetState Shared Collections on ${event.reason}");
       setState(() {});
     });
     _loggedOutEvent = Bus.instance.on<UserLoggedOutEvent>().listen((event) {

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -109,7 +109,7 @@ class _GalleryState extends State<Gallery> {
       for (final event in widget.forceReloadEvents) {
         _forceReloadEventSubscriptions.add(
           event.listen((event) async {
-            _logger.info("Force reload triggered");
+            _logger.info("Force reload $event");
             final result = await _loadFiles();
             _setFilesAndReload(result.files);
           }),

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/constants.dart';
@@ -77,16 +78,18 @@ class _GalleryState extends State<Gallery> {
   StreamSubscription<FilesUpdatedEvent> _reloadEventSubscription;
   StreamSubscription<TabDoubleTapEvent> _tabDoubleTapEvent;
   final _forceReloadEventSubscriptions = <StreamSubscription<Event>>[];
+  String _logTag;
 
   @override
   void initState() {
-    _logger = Logger("Gallery_" + widget.tagPrefix);
+    _logTag =
+        "Gallery_${widget.tagPrefix}${kDebugMode ? "_" + widget.albumName : ""}";
+    _logger = Logger(_logTag);
+    _logger.finest("init Gallery");
     _itemScroller = ItemScrollController();
-
-    _logger.info("initState");
     if (widget.reloadEvent != null) {
       _reloadEventSubscription = widget.reloadEvent.listen((event) async {
-        _logger.info("Building gallery because reload event fired");
+        _logger.info("Reloading ALL files on ${event.type.name} event");
         final result = await _loadFiles();
         _onFilesLoaded(result.files);
       });
@@ -160,18 +163,18 @@ class _GalleryState extends State<Gallery> {
 
   // Collates files and returns `true` if it resulted in a gallery reload
   bool _onFilesLoaded(List<File> files) {
-    final collatedFiles = _collateFiles(files);
-    if (_collatedFiles.length != collatedFiles.length ||
+    final updatedCollatedFiles = _collateFiles(files);
+    if (_collatedFiles.length != updatedCollatedFiles.length ||
         _collatedFiles.isEmpty) {
       if (mounted) {
         setState(() {
           _hasLoadedFiles = true;
-          _collatedFiles = collatedFiles;
+          _collatedFiles = updatedCollatedFiles;
         });
       }
       return true;
     } else {
-      _collatedFiles = collatedFiles;
+      _collatedFiles = updatedCollatedFiles;
       return false;
     }
   }
@@ -188,7 +191,7 @@ class _GalleryState extends State<Gallery> {
 
   @override
   Widget build(BuildContext context) {
-    _logger.info("Building " + widget.tagPrefix);
+    _logger.finest("Building Gallery  ${widget.tagPrefix}");
     if (!_hasLoadedFiles) {
       return const EnteLoadingWidget();
     }
@@ -238,6 +241,7 @@ class _GalleryState extends State<Gallery> {
               .where((event) => event.tag == widget.tagPrefix)
               .map((event) => event.index),
           smallerTodayFont: widget.smallerTodayFont,
+          logTag: _logTag,
         );
         if (widget.header != null && index == 0) {
           gallery = Column(children: [widget.header, gallery]);

--- a/lib/ui/viewer/gallery/gallery.dart
+++ b/lib/ui/viewer/gallery/gallery.dart
@@ -109,7 +109,8 @@ class _GalleryState extends State<Gallery> {
       for (final event in widget.forceReloadEvents) {
         _forceReloadEventSubscriptions.add(
           event.listen((event) async {
-            _logger.info("Force reload $event");
+            _logger.info(event.reason);
+
             final result = await _loadFiles();
             _setFilesAndReload(result.files);
           }),

--- a/lib/utils/delete_file_util.dart
+++ b/lib/utils/delete_file_util.dart
@@ -115,6 +115,7 @@ Future<void> deleteFilesFromEverywhere(
           deletedFiles
               .where((file) => file.collectionID == collectionID)
               .toList(),
+          "deleteFilesEverywhere",
           type: EventType.deletedFromEverywhere,
         ),
       );
@@ -176,6 +177,7 @@ Future<void> deleteFilesFromRemoteOnly(
       CollectionUpdatedEvent(
         collectionID,
         files.where((file) => file.collectionID == collectionID).toList(),
+        "deleteFromRemoteOnly",
         type: EventType.deletedFromRemote,
       ),
     );
@@ -266,8 +268,13 @@ Future<bool> deleteFromTrash(BuildContext context, List<File> files) async {
     await TrashSyncService.instance.deleteFromTrash(files);
     showShortToast(context, "Successfully deleted");
     await dialog.hide();
-    Bus.instance
-        .fire(FilesUpdatedEvent(files, type: EventType.deletedFromEverywhere));
+    Bus.instance.fire(
+      FilesUpdatedEvent(
+        files,
+        type: EventType.deletedFromEverywhere,
+        source: "deleteFromTrash",
+      ),
+    );
     return true;
   } catch (e, s) {
     _logger.info("failed to delete from trash", e, s);

--- a/lib/utils/magic_util.dart
+++ b/lib/utils/magic_util.dart
@@ -61,7 +61,7 @@ Future<void> changeCollectionVisibility(
     final Map<String, dynamic> update = {magicKeyVisibility: newVisibility};
     await CollectionsService.instance.updateMagicMetadata(collection, update);
     // Force reload home gallery to pull in the now unarchived files
-    Bus.instance.fire(ForceReloadHomeGalleryEvent());
+    Bus.instance.fire(ForceReloadHomeGalleryEvent("CollectionArchiveChange"));
     showShortToast(
       context,
       newVisibility == visibilityArchive
@@ -177,7 +177,7 @@ Future<void> _updatePublicMetadata(
     }
 
     if (_shouldReloadGallery(key)) {
-      Bus.instance.fire(ForceReloadHomeGalleryEvent());
+      Bus.instance.fire(ForceReloadHomeGalleryEvent("FileMetadataChange-$key"));
     }
   } catch (e, s) {
     _logger.severe("failed to update $key = $value", e, s);


### PR DESCRIPTION
## Description

As of today, lot of state refresh happens on various events.   Just by looking at the logs, it's difficult/time-consuming to reason/guess why a event was fired and for which widget.

Post logging changes and improvements, we will be in better shape for debugging issues and make performance improvements by removing redundant state refreshes and leverage debounce to avoid quick refreshes. 

## Test Plan
👁️  🪵 👁️  
