### PR TITLE
bug fix : selected files thumbnail not not getting refreshed on 'cancel'

### DIFF
--- a/lib/events/clear_selections.dart
+++ b/lib/events/clear_selections.dart
@@ -1,0 +1,3 @@
+import 'package:photos/events/event.dart';
+
+class ClearSelections extends Event {}

--- a/lib/models/selected_files.dart
+++ b/lib/models/selected_files.dart
@@ -1,5 +1,7 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:photos/core/event_bus.dart';
 import 'package:photos/models/file.dart';
 
 class SelectedFiles extends ChangeNotifier {
@@ -51,6 +53,7 @@ class SelectedFiles extends ChangeNotifier {
   }
 
   void clearAll() {
+    Bus.instance.fire(const ClearSelectionEvent());
     lastSelections.addAll(files);
     files.clear();
     notifyListeners();

--- a/lib/ui/huge_listview/lazy_loading_gallery.dart
+++ b/lib/ui/huge_listview/lazy_loading_gallery.dart
@@ -5,9 +5,11 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/constants.dart';
+import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/files_updated_event.dart';
 import 'package:photos/models/file.dart';
 import 'package:photos/models/selected_files.dart';
@@ -291,12 +293,19 @@ class LazyLoadingGridView extends StatefulWidget {
 
 class _LazyLoadingGridViewState extends State<LazyLoadingGridView> {
   bool _shouldRender;
+  StreamSubscription<ClearSelectionEvent> _clearSelectionEvent;
 
   @override
   void initState() {
     _shouldRender = widget.shouldRender;
     widget.shouldSelectAll.addListener(_shouldSelectAllListener);
     widget.selectedFiles.addListener(_selectedFilesListener);
+    _clearSelectionEvent =
+        Bus.instance.on<ClearSelectionEvent>().listen((event) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
     super.initState();
   }
 
@@ -304,6 +313,7 @@ class _LazyLoadingGridViewState extends State<LazyLoadingGridView> {
   void dispose() {
     widget.selectedFiles.removeListener(_selectedFilesListener);
     widget.shouldSelectAll.removeListener(_shouldSelectAllListener);
+    _clearSelectionEvent.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
Rebuild gallery on cancelling all selections.

# Observations from testing

At most this is rebuilding 16 girds (16 days) of a gallery. If the girds that are rebuild have more files in them, the number of girds that are getting rebuild gets reduced. 
