### PR TITLE
close settings drawer on autoLogOut

### DIFF
--- a/lib/ui/home_widget.dart
+++ b/lib/ui/home_widget.dart
@@ -201,6 +201,7 @@ class _HomeWidgetState extends State<HomeWidget> {
           ),
           onPressed: () async {
             Navigator.of(context, rootNavigator: true).pop('dialog');
+            Navigator.of(context).popUntil((route) => route.isFirst);
             final dialog = createProgressDialog(context, "Logging out...");
             await dialog.show();
             await Configuration.instance.logout();


### PR DESCRIPTION
If the settings drawer was open when auto log out happens (For example, session expired), it was not getting closed, have fixed that now.
