### PR TITLE
Runtime error fix

### DIFF
--- a/lib/utils/file_uploader.dart
+++ b/lib/utils/file_uploader.dart
@@ -153,7 +153,7 @@ class FileUploader {
       }
       return CollectionsService.instance
           .addToCollection(collectionID, [uploadedFile]).then((aVoid) {
-        return uploadedFile;
+        return uploadedFile as File;
       });
     });
   }


### PR DESCRIPTION
## Description

The `upload` method expects a return type of `Future<File>` and not `Future<dynamic>`. In dart versions older than 2.9, what was getting returned would get implicitly downcasted from `Future<dynamic>` to `Future<File>`. In newer dart versions >= 2.9, it needs to be explicitly downcasted.


